### PR TITLE
chore(rust): Bump rust edition to 2021

### DIFF
--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brane-cfg"
 rust-version = "1.81"
-edition = "2018"
+edition = "2021"
 authors = ["Onno Valkering", "Tim Müller"]
 version.workspace = true
 repository.workspace = true

--- a/brane-dsl/Cargo.toml
+++ b/brane-dsl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brane-dsl"
 rust-version = "1.81"
-edition = "2018"
+edition = "2021"
 version.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brane-job"
 rust-version = "1.81"
-edition = "2018"
+edition = "2021"
 version.workspace = true
 repository.workspace = true
 authors = { workspace = true }

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brane-let"
 rust-version = "1.81"
-edition = "2018"
+edition = "2021"
 version.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/brane-log/Cargo.toml
+++ b/brane-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brane-log"
-edition = "2018"
+edition = "2021"
 rust-version = "1.74.1"
 version.workspace = true
 repository.workspace = true

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "specifications"
 rust-version = "1.81"
-edition = "2018"
+edition = "2021"
 version.workspace = true
 repository.workspace = true
 authors.workspace = true


### PR DESCRIPTION
In case anybody is wondering. At time of writing 2024 is out, but this
would be a bad idea as it would increase our MSRV to 1.85. Limiting
ourselves to one single rust version for support.
