### PR TITLE
chore(rust): Set default toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        rust: [stable]
     uses: ./.github/workflows/mixin-cargo-check.yml
     with:
       os: ${{ matrix.os }}
-      rust-version: ${{ matrix.rust }}
       packages: workspace
 
   # Frontend packages are compiled for windows and macOS as well
@@ -33,12 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        rust: [stable]
 
     uses: ./.github/workflows/mixin-cargo-check.yml
     with:
       os: "${{ matrix.os }}"
-      rust-version: "${{ matrix.rust }}"
       packages: frontend
 
   test:
@@ -49,7 +45,6 @@ jobs:
     uses: ./.github/workflows/mixin-cargo-test.yml
     with:
       os: ubuntu-24.04
-      rust-version: stable
 
   test-coverage:
     needs: test
@@ -60,7 +55,6 @@ jobs:
     secrets: inherit
     with:
       os: ubuntu-24.04
-      rust-version: stable
 
   clippy:
     needs: check-stable-all
@@ -68,7 +62,6 @@ jobs:
     uses: ./.github/workflows/mixin-cargo-clippy.yml
     with:
       os: ubuntu-24.04
-      rust-version: stable
 
   # We use the nightly formatter because it has additional formatter settings
   fmt:
@@ -103,10 +96,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
       - name: "Compile documentation"
         run: cargo doc --workspace --no-deps --all-features
       - name: "Run doc tests"
@@ -117,10 +106,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
       - name: Run direct minimal versions
@@ -154,10 +139,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
       - name: "Check if lockfile update is necessary"
         # This will attempt an update all dependencies in our workspace (not transient).
         # This should not be the case, so if it can locked will prevent it and return a non-zero exit code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
+      - name: Show toolchain
+        run: rustup show active-toolchain
       - name: Run formatter
         run: cargo +nightly fmt --all --check
 
@@ -96,6 +98,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Show toolchain
+        run: rustup show active-toolchain
       - name: "Compile documentation"
         run: cargo doc --workspace --no-deps --all-features
       - name: "Run doc tests"
@@ -108,6 +112,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
+      - name: Show toolchain
+        run: rustup show active-toolchain
       - name: Run direct minimal versions
         run: cargo minimal-versions check --workspace --direct
 
@@ -123,6 +129,9 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
       - name: Install Cargo MSRV
         run: cargo binstall --no-confirm cargo-msrv --version ^0.16
+      - name: Show toolchain
+        run: rustup show active-toolchain
+
       - name: Install dependencies
         run: sudo apt update; sudo apt install -y yq
       - name: "Run minimum supported rust version"
@@ -139,6 +148,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Show toolchain
+        run: rustup show active-toolchain
       - name: "Check if lockfile update is necessary"
         # This will attempt an update all dependencies in our workspace (not transient).
         # This should not be the case, so if it can locked will prevent it and return a non-zero exit code

--- a/.github/workflows/mixin-cargo-check.yml
+++ b/.github/workflows/mixin-cargo-check.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       rust-version:
-        required: true
+        required: false
         type: string
       packages:
         required: true
@@ -22,11 +22,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          components: rustfmt, clippy
+      # Note: Maybe this is done by rustup implicitly
+      # - name: Install rust toolchain
+      #   uses: dtolnay/rust-toolchain@master
+      #   if: inputs.rust-version != ''
+      #   with:
+      #     toolchain: ${{ inputs.rust-version }}
+
+      - name: Override active rustup toolchain
+        if: inputs.rust-version != ''
+        run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV
+
+      - name: Show toolchain
+        run: rustup show active-toolchain
 
       - name: Install dependencies
         if: startsWith(inputs.os, 'ubuntu-')

--- a/.github/workflows/mixin-cargo-check.yml
+++ b/.github/workflows/mixin-cargo-check.yml
@@ -22,13 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Note: Maybe this is done by rustup implicitly
-      # - name: Install rust toolchain
-      #   uses: dtolnay/rust-toolchain@master
-      #   if: inputs.rust-version != ''
-      #   with:
-      #     toolchain: ${{ inputs.rust-version }}
-
       - name: Override active rustup toolchain
         if: inputs.rust-version != ''
         run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV

--- a/.github/workflows/mixin-cargo-clippy.yml
+++ b/.github/workflows/mixin-cargo-clippy.yml
@@ -19,13 +19,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Note: Maybe this is done by rustup implicitly
-      # - name: Install rust toolchain
-      #   uses: dtolnay/rust-toolchain@master
-      #   if: inputs.rust-version != ''
-      #   with:
-      #     toolchain: ${{ inputs.rust-version }}
-
       - name: Override active rustup toolchain
         if: inputs.rust-version != ''
         run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV

--- a/.github/workflows/mixin-cargo-clippy.yml
+++ b/.github/workflows/mixin-cargo-clippy.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       rust-version:
-        required: true
+        required: false
         type: string
 
 jobs:
@@ -19,11 +19,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          components: rustfmt, clippy
+      # Note: Maybe this is done by rustup implicitly
+      # - name: Install rust toolchain
+      #   uses: dtolnay/rust-toolchain@master
+      #   if: inputs.rust-version != ''
+      #   with:
+      #     toolchain: ${{ inputs.rust-version }}
+
+      - name: Override active rustup toolchain
+        if: inputs.rust-version != ''
+        run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV
+
+      - name: Show toolchain
+        run: rustup show active-toolchain
+
+      - name: Install Clippy
+        run: rustup component add clippy
 
       - name: Run clippy
         run: cargo clippy --workspace

--- a/.github/workflows/mixin-cargo-llvm-cov.yml
+++ b/.github/workflows/mixin-cargo-llvm-cov.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       rust-version:
-        required: true
+        required: false
         type: string
 
 jobs:
@@ -19,11 +19,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          components: rustfmt, clippy
+      # Note: Maybe this is done by rustup implicitly
+      # - name: Install rust toolchain
+      #   uses: dtolnay/rust-toolchain@master
+      #   if: inputs.rust-version != ''
+      #   with:
+      #     toolchain: ${{ inputs.rust-version }}
+
+      - name: Override active rustup toolchain
+        if: inputs.rust-version != ''
+        run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV
+
+      - name: Show toolchain
+        run: rustup show active-toolchain
 
       - name: Install dependencies
         if: startsWith(inputs.os, 'ubuntu-')

--- a/.github/workflows/mixin-cargo-llvm-cov.yml
+++ b/.github/workflows/mixin-cargo-llvm-cov.yml
@@ -19,13 +19,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Note: Maybe this is done by rustup implicitly
-      # - name: Install rust toolchain
-      #   uses: dtolnay/rust-toolchain@master
-      #   if: inputs.rust-version != ''
-      #   with:
-      #     toolchain: ${{ inputs.rust-version }}
-
       - name: Override active rustup toolchain
         if: inputs.rust-version != ''
         run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV

--- a/.github/workflows/mixin-cargo-test.yml
+++ b/.github/workflows/mixin-cargo-test.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       rust-version:
-        required: true
+        required: false
         type: string
 
 jobs:
@@ -19,11 +19,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          components: rustfmt, clippy
+      # Note: Maybe this is done by rustup implicitly
+      # - name: Install rust toolchain
+      #   uses: dtolnay/rust-toolchain@master
+      #   if: inputs.rust-version != ''
+      #   with:
+      #     toolchain: ${{ inputs.rust-version }}
+
+      - name: Override active rustup toolchain
+        if: inputs.rust-version != ''
+        run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV
+
+      - name: Show toolchain
+        run: rustup show active-toolchain
 
       - name: Install dependencies
         if: startsWith(inputs.os, 'ubuntu-')

--- a/.github/workflows/mixin-cargo-test.yml
+++ b/.github/workflows/mixin-cargo-test.yml
@@ -19,13 +19,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Note: Maybe this is done by rustup implicitly
-      # - name: Install rust toolchain
-      #   uses: dtolnay/rust-toolchain@master
-      #   if: inputs.rust-version != ''
-      #   with:
-      #     toolchain: ${{ inputs.rust-version }}
-
       - name: Override active rustup toolchain
         if: inputs.rust-version != ''
         run: echo "RUSTUP_TOOLCHAIN=${{ inputs.rust-version }}" >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,18 +25,7 @@ jobs:
   clippy-nightly:
     needs: check-nightly
     name: "Clippy (Nightly)"
-    continue-on-error: true
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: clippy
-
-      - name: Run unit tests
-        run: cargo +nightly clippy --workspace
+    uses: ./.github/workflows/mixin-cargo-clippy.yml
+    with:
+      os: ubuntu-24.04
+      rust-version: nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85"
+profile = "minimal"


### PR DESCRIPTION
Inspired by this blogpost (https://swatinem.de/blog/rust-toolchain/) 
we are setting our rust toolchain and will
start managing it as a dependency. This will make compiling more easy in
case this project is ever shelved. Additionally, once used in CI it will
ensure that CI should not randomly break when new clippy checks land in
the latest rust version for example.

- [x] Update CI to use the new `rust-toolchain.toml` file in jobs (Done in #231) 
- [ ] Set up periodic checking for other versions up till the MSRV
