### PR TITLE
chore(deps): Enable rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           components: rustfmt
       - name: Show toolchain
         run: rustup show active-toolchain
+      - uses: Swatinem/rust-cache@v2
       - name: Run formatter
         run: cargo +nightly fmt --all --check
 
@@ -100,6 +101,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Show toolchain
         run: rustup show active-toolchain
+      - uses: Swatinem/rust-cache@v2
       - name: "Compile documentation"
         run: cargo doc --workspace --no-deps --all-features
       - name: "Run doc tests"
@@ -114,6 +116,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-minimal-versions
       - name: Show toolchain
         run: rustup show active-toolchain
+      - uses: Swatinem/rust-cache@v2
       - name: Run direct minimal versions
         run: cargo minimal-versions check --workspace --direct
 
@@ -131,6 +134,8 @@ jobs:
         run: cargo binstall --no-confirm cargo-msrv --version ^0.16
       - name: Show toolchain
         run: rustup show active-toolchain
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: sudo apt update; sudo apt install -y yq
@@ -150,6 +155,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Show toolchain
         run: rustup show active-toolchain
+      - uses: Swatinem/rust-cache@v2
       - name: "Check if lockfile update is necessary"
         # This will attempt an update all dependencies in our workspace (not transient).
         # This should not be the case, so if it can locked will prevent it and return a non-zero exit code

--- a/.github/workflows/mixin-cargo-check.yml
+++ b/.github/workflows/mixin-cargo-check.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Install Cargo Hack
         uses: taiki-e/install-action@cargo-hack
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Check project (Workspace)
         if: inputs.packages == 'workspace'
         run: cargo hack --feature-powerset check --workspace

--- a/.github/workflows/mixin-cargo-clippy.yml
+++ b/.github/workflows/mixin-cargo-clippy.yml
@@ -29,5 +29,7 @@ jobs:
       - name: Install Clippy
         run: rustup component add clippy
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Run clippy
         run: cargo clippy --workspace

--- a/.github/workflows/mixin-cargo-llvm-cov.yml
+++ b/.github/workflows/mixin-cargo-llvm-cov.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
 

--- a/.github/workflows/mixin-cargo-test.yml
+++ b/.github/workflows/mixin-cargo-test.yml
@@ -30,5 +30,7 @@ jobs:
         if: startsWith(inputs.os, 'ubuntu-')
         run: sudo apt update && sudo apt install -y libsqlite3-dev
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Run tests
         run: cargo test --workspace


### PR DESCRIPTION
By caching dependencies, we might be able to speed up our CI

Very non-scientific measurement decreased CI times from 25 minutes to 6 minutes, more often it should lie somewhere in between, but this seems promising.
