### PR TITLE
chore: Rename epi-project to braneframework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Brane framework will be documented in this file.
 
 ## [4.0.0] - TODO
-This update sees a lot of changes. Most notably, it integrated with the [policy reasoner effort](https://github.com/epi-project/policy-reasoner) (see issue [#60](https://github.com/epi-project/brane/issues/60)).
+This update sees a lot of changes. Most notably, it integrated with the [policy reasoner effort](https://github.com/braneframework/policy-reasoner) (see issue [#60](https://github.com/braneframework/brane/issues/60)).
 
 ### Added
 - Attributes to BraneScript (e.g., `#[tag("amy.foo")]` or `#![on("foo")]`).
@@ -16,7 +16,7 @@ This update sees a lot of changes. Most notably, it integrated with the [policy 
 - `TEST_LOGGER` and `TEST_FILES` environment variables to any unit tests using `brane_shr::utilities::test_on_dsl_files*`.
   - If you give `TEST_LOGGER=1` or `TEST_LOGGER=true`, then it instantiates a `log`-capable logger ([humanlog](https://github.com/Lut99/humanlog-rs)).
   - If you give `TEST_FILES=<file1>[,<file2>[...]]`, then only the given files are tested instead of all in the `tests` folder. The files are matched by name, and then specifically an `end_of()`-call.
-- Integration with the [policy reasoner effort](https://github.com/epi-project/policy-reasoner):
+- Integration with the [policy reasoner effort](https://github.com/braneframework/policy-reasoner):
   - Part of this is:
     - Adding `brane check` to validate workflow against all checkers without running anything.
       - Note, this is currently imperfect, as checkers answer questions with pre-workflow state. This means that they may assume they won't have a dataset, while they would have while executing the workflow as a result of a previous step. To fix, needs some kind of hypothetical state specification to either `brane-api` or the `policy-reasoner`.
@@ -36,7 +36,7 @@ This update sees a lot of changes. Most notably, it integrated with the [policy 
     - Removing `branectl generate policies` as the old file is no longer used \[**breaking change**\].
 - Graceful shutdown for instance services (`brane-api`, `brane-drv`, `brane-job`, `brane-plr`, `brane-reg`).
 - Passing the `--debug` flag is now the default to the builtin `docker-compose-*.yml` files in `branectl`. If you want to revert to default behaviour, extract the compose file(s) first (`branectl extract compose ...`), change it accordingly, and then pass it during lifetime commands (e.g., `branectl start -f path/to/compose/file ...`).
-- Minimum Rust versions to all `Cargo.toml` files ([#86](https://github.com/epi-project/brane/pull/86)).
+- Minimum Rust versions to all `Cargo.toml` files ([#86](https://github.com/braneframework/brane/pull/86)).
 
 ### Changed
 - The WIR no longer has a dynamic definition table, but simply a large table spanning all scopes.
@@ -47,7 +47,7 @@ This update sees a lot of changes. Most notably, it integrated with the [policy 
 - More error prints to use a trace (i.e., `Error::source()`) rather than endless colons.
 - `brane-drv` and `brane-plr` to communicate using HTTP instead of Kafka, finally. This allows us to finally get rid of `aux-kafka` and `aux-zookeeper` \[**breaking change**\].
 - `branectl` now embeds `cfssl`/`cfssljson` binaries, either downloaded or compiled from source at compile time. The latter because 1.6.3 does not include ARM binaries by default.
-- Now relying on `serde_yml` instead of `serde_yaml` because the latter is no longer maintained ([#84](https://github.com/epi-project/brane/pull/84)).
+- Now relying on `serde_yml` instead of `serde_yaml` because the latter is no longer maintained ([#84](https://github.com/braneframework/brane/pull/84)).
 - `brane`s interface has been restructured. Several commands operating on packages and workflows have been grouped under the `package` and `workflow` subcommands respectively.
 
 ### Fixed
@@ -57,19 +57,19 @@ This update sees a lot of changes. Most notably, it integrated with the [policy 
 - CI/CD in the repository by moving most of it to scripts which we _can_ test offline.
 - The WIR using platform-specific `usize::MAX` to detect the main function. This has been replaced with `FunctionId` (`brane-ast`) and `ProgramCounter` (`brane-exe`) \[**breaking change**\].
 - `make.py` relying on buildx being the default Docker builder.
-- `make.py` reporting wrong names in `make.py --targets` for `*-image-build` targets ([#78](https://github.com/epi-project/brane/pull/78)).
-- `brane instance edit` accidentally appending `info.yml` twice ([#73](https://github.com/epi-project/brane/pull/73)).
-- Various examples not running (see [#76](https://github.com/epi-project/brane/pull/76)).
+- `make.py` reporting wrong names in `make.py --targets` for `*-image-build` targets ([#78](https://github.com/braneframework/brane/pull/78)).
+- `brane instance edit` accidentally appending `info.yml` twice ([#73](https://github.com/braneframework/brane/pull/73)).
+- Various examples not running (see [#76](https://github.com/braneframework/brane/pull/76)).
 - `cargo clippy`-warnings.
-- `Cargo.toml` not committing to patch-level minimum versions ([#92](https://github.com/epi-project/brane/pull/92)). Extra thanks to @DanielVoogsgerd for this one.
-- `specifications` not correctly setting the `rc` feature-flag for `serde` ([#90](https://github.com/epi-project/brane/pull/90)).
+- `Cargo.toml` not committing to patch-level minimum versions ([#92](https://github.com/braneframework/brane/pull/92)). Extra thanks to @DanielVoogsgerd for this one.
+- `specifications` not correctly setting the `rc` feature-flag for `serde` ([#90](https://github.com/braneframework/brane/pull/90)).
 
 ### Removed
 - `brane-aos` has been completely removed from Brane
 
 ## [3.0.0] - 2023-10-22
 ### Added
-- The `libbrane_cli.so` library (`brane-cli-c` crate), which provides C-bindings to the client functionality of the `brane` CLI tool. This can be used by other projects (e.g., [Brane IDE](https://github.com/epi-project/brane-ide)) to provide client functionality when written in C/C++.
+- The `libbrane_cli.so` library (`brane-cli-c` crate), which provides C-bindings to the client functionality of the `brane` CLI tool. This can be used by other projects (e.g., [Brane IDE](https://github.com/braneframework/brane-ide)) to provide client functionality when written in C/C++.
 - The `branectl upgrade` subcommand, which can be used to upgrade old backend-facing config files to the new style.
   - Added support for `node.yml` files
 - The `brane upgrade` subcommand, which can be used to upgrade old user-facing config files to the new style.
@@ -124,7 +124,7 @@ This update sees a lot of changes. Most notably, it integrated with the [policy 
 - `make.py` to move the download capabilities to `branectl`, allowing for a friendlier (and easier) interface.
 - `aux-xenon` to be an image in the Brane release tar (central node).
 - The general layout of `node.yml` to be more sensible (it focusses on services rather than names, ports, etc) [**breaking change**]
-- The `socksx` dependency to use [our own fork](https://github.com/epi-project/socksx) instead of [Onno's repository](https://github.com/onnovalkering/socksx) to achieve Windows compatibility for the `brane` CLI (see above).
+- The `socksx` dependency to use [our own fork](https://github.com/braneframework/socksx) instead of [Onno's repository](https://github.com/onnovalkering/socksx) to achieve Windows compatibility for the `brane` CLI (see above).
 - `main.py`'s output directory for `aux-xenon` now respects the build mode (i.e., release or `--dev`).
 - The `-m`/`--mode` option in `branectl` to `--image-dir`, for a more sensible interface.
 - `--version` to be come a positional parameter in `brane test` [**breaking change**]
@@ -179,9 +179,9 @@ This release basically sees the release of an entirely rebuilt framework. Expect
   - Fixing data- and result analysis w.r.t. loops
 
 ### Known bugs
-- [[#27](https://github.com/epi-project/brane/issues/27)] The framework cannot currently connect to domains that are accessed by IP instead of hostname (resulting in TLS errors; check [this issue](https://github.com/seanmonstar/reqwest/issues/1328)). As a workaround, use the `Hostnames` option in `node.yml` to provide hostnames for a set of IP addresses and use those instead.
-- [[#28](https://github.com/epi-project/brane/issues/28)] The REPL is quite buggy as well, often not properly carrying information between two statements. For now, as a workaround, put the loose statements in a single line to keep the information consistent.
-- [[#29](https://github.com/epi-project/brane/issues/29)] Data transfer pre-task execution is unreasonably slow, making the framework effectively unusable for use-cases which rely on iteration in BraneScript.
+- [[#27](https://github.com/braneframework/brane/issues/27)] The framework cannot currently connect to domains that are accessed by IP instead of hostname (resulting in TLS errors; check [this issue](https://github.com/seanmonstar/reqwest/issues/1328)). As a workaround, use the `Hostnames` option in `node.yml` to provide hostnames for a set of IP addresses and use those instead.
+- [[#28](https://github.com/braneframework/brane/issues/28)] The REPL is quite buggy as well, often not properly carrying information between two statements. For now, as a workaround, put the loose statements in a single line to keep the information consistent.
+- [[#29](https://github.com/braneframework/brane/issues/29)] Data transfer pre-task execution is unreasonably slow, making the framework effectively unusable for use-cases which rely on iteration in BraneScript.
 
 ## [0.6.3] - 2022-05-31
 ### Added
@@ -262,7 +262,7 @@ This release basically sees the release of an entirely rebuilt framework. Expect
 - The Brane executable making files instead of directories when making standard config directories.
 - Docker not refreshing images with the same version after building them or pushing them.
 - brane-job not passing the 'debug' flag to branelet.
-- small issues that prevented [brane-ide](https://github.com/epi-project/brane) from working.
+- small issues that prevented [brane-ide](https://github.com/braneframework/brane) from working.
 - brane-drv crashing when receiving out-of-order status update messages.
 - `kube` location kind, so it's now working and tested again.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "audit-logger"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "async-trait",
  "auth-resolver",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "auth-resolver"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "async-trait",
  "serde",
@@ -1373,7 +1373,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "deliberation"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "brane-ast 3.0.0 (git+https://github.com/epi-project/brane)",
  "brane-exe 3.0.0 (git+https://github.com/epi-project/brane)",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "eflint-to-json"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "async-recursion",
  "console",
@@ -3332,7 +3332,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "policy"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "reasonerconn"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "socksx"
 version = "2.0.0"
-source = "git+https://github.com/epi-project/socksx?tag=v2.0.0#9ad245649bb8a3e155aea95313cbcb9d7850ff6d"
+source = "git+https://github.com/braneframework/socksx?tag=v2.0.0#9ad245649bb8a3e155aea95313cbcb9d7850ff6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4435,7 +4435,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "srv"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "audit-logger",
  "auth-resolver",
@@ -4467,7 +4467,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "state-resolver"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "async-trait",
  "serde",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "workflow"
 version = "0.1.0"
-source = "git+https://github.com/epi-project/policy-reasoner#a80fea4ffee364c63ee72daa41e949c4673c49d8"
+source = "git+https://github.com/braneframework/policy-reasoner#a5b56bbdfde789ae1579f37067f81fc7ba8c04d0"
 dependencies = [
  "brane-ast 3.0.0 (git+https://github.com/epi-project/brane)",
  "brane-exe 3.0.0 (git+https://github.com/epi-project/brane)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ version = "3.0.0"
 edition = "2021"
 authors = [ "Onno Valkering", "Tim Müller" ]
 description = "The Brane Framework is a workflow execution system that is capable of dealing with sensitive dataset. Created for the [EPI project](https://enablingpersonalizedinterventions.nl)."
-repository = "https://github.com/epi-project/brane"
+repository = "https://github.com/braneframework/brane"
 documentation = "https://wiki.enablingpersonalizedinterventions.nl"
 license = "Apache-2.0"
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,7 +21,7 @@
 # Note: we'd like to go to 22.04, but for now this is in conflict with OpenSSL
 # Note: actually we're doing 22.04 but using 21.10 repos
 FROM ubuntu:22.04 AS brane-base
-LABEL org.opencontainers.image.source https://github.com/epi-project/Brane
+LABEL org.opencontainers.image.source https://github.com/braneframework/brane
 
 # Add the log directory
 RUN mkdir -p /logs/profile

--- a/Dockerfile.rls
+++ b/Dockerfile.rls
@@ -11,7 +11,7 @@
 ##### BUILD STAGE #####
 ### This file will act as the bottom for both builder images
 FROM rust:1 AS build-common
-LABEL org.opencontainers.image.source https://github.com/epi-project/brane
+LABEL org.opencontainers.image.source https://github.com/braneframework/brane
 
 # Install build dependencies (that are not in the rust image already)
 RUN apt-get update && apt-get install -y \
@@ -28,7 +28,7 @@ COPY . /build
 
 ### This file does the Brane services
 FROM build-common AS build-brane
-LABEL org.opencontainers.image.source https://github.com/epi-project/brane
+LABEL org.opencontainers.image.source https://github.com/braneframework/brane
 
 # Build optimized binaries
 WORKDIR /build
@@ -57,14 +57,14 @@ ENTRYPOINT [ "/bin/bash" ]
 
 ### This file does the policy reasoner service
 FROM build-common AS build-policy-reasoner
-LABEL org.opencontainers.image.source https://github.com/epi-project/brane
+LABEL org.opencontainers.image.source https://github.com/braneframework/brane
 
 # Fetch the reasoner code next
 WORKDIR /
 ARG REASONER=eflint
 ARG REASONER_BRANCH=main
-ADD "http://github.com/epi-project/policy-reasoner/zipball/${REASONER_BRANCH}/" /policy-reasoner.zip
-RUN unzip /policy-reasoner.zip && mv /epi-project-policy-reasoner* /policy-reasoner
+ADD "http://github.com/braneframework/policy-reasoner/zipball/${REASONER_BRANCH}/" /policy-reasoner.zip
+RUN unzip /policy-reasoner.zip && mv /braneframework-policy-reasoner* /policy-reasoner
 
 # Touch a `policy.db` into action to avoid the policy reasoner's `build.rs` building it for us (unnecessary)
 RUN mkdir -p /policy-reasoner/data && touch /policy-reasoner/data/policy.db
@@ -110,7 +110,7 @@ RUN PATH="$PATH:/go/bin" \
 ##### BASE IMAGE #####
 # This image defines the base image for all Brane service images.
 FROM ubuntu:22.04 AS brane-base
-LABEL org.opencontainers.image.source https://github.com/epi-project/brane
+LABEL org.opencontainers.image.source https://github.com/braneframework/brane
 
 # Add the log directory
 RUN mkdir -p /logs/profile

--- a/brane-cli/src/build_common.rs
+++ b/brane-cli/src/build_common.rs
@@ -44,7 +44,7 @@ macro_rules! writeln_build {
 /***** COMMON CONSTANTS */
 /// The URL which we use to pull the latest branelet executable from.
 pub const BRANELET_URL: &str =
-    concat!("https://github.com/epi-project/brane/releases/download/", concat!("v", env!("CARGO_PKG_VERSION")), "/branelet");
+    concat!("https://github.com/braneframework/brane/releases/download/", concat!("v", env!("CARGO_PKG_VERSION")), "/branelet");
 
 
 

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -27,7 +27,7 @@ diesel = { version = "2.2.3", features = ["sqlite"] }
 diesel_migrations = "2.2.0"
 dirs = "6.0.0"
 dotenvy = "0.15.0"
-eflint-to-json = { git = "https://github.com/epi-project/policy-reasoner" }
+eflint-to-json = { git = "https://github.com/braneframework/policy-reasoner" }
 enum-debug.workspace = true
 error-trace.workspace = true
 humanlog.workspace = true
@@ -37,8 +37,8 @@ jsonwebtoken = "9.2.0"
 lazy_static = "1.4.0"
 log = "0.4.22"
 names.workspace = true
-policy = { git = "https://github.com/epi-project/policy-reasoner" }
-srv = { git = "https://github.com/epi-project/policy-reasoner" }
+policy = { git = "https://github.com/braneframework/policy-reasoner" }
+srv = { git = "https://github.com/braneframework/policy-reasoner" }
 rand = "0.9.0"
 reqwest = { version = "0.12.0" }
 serde = { version = "1.0.204", features = ["derive"] }

--- a/brane-ctl/src/cli.rs
+++ b/brane-ctl/src/cli.rs
@@ -353,7 +353,7 @@ pub(crate) enum GenerateSubcommand {
             short,
             long,
             default_value = "main",
-            help = "The branch of the `https://github.com/epi-project/policy-reasoner` repository from which to pull the Diesel migrations."
+            help = "The branch of the `https://github.com/braneframework/policy-reasoner` repository from which to pull the Diesel migrations."
         )]
         branch:   String,
     },

--- a/brane-ctl/src/download.rs
+++ b/brane-ctl/src/download.rs
@@ -245,9 +245,9 @@ pub async fn services(
         DownloadServicesSubcommand::Central => {
             // Resolve the address to use
             let address: String = if version.is_latest() {
-                format!("https://github.com/epi-project/brane/releases/latest/download/instance-{}.tar.gz", arch.brane())
+                format!("https://github.com/braneframework/brane/releases/latest/download/instance-{}.tar.gz", arch.brane())
             } else {
-                format!("https://github.com/epi-project/brane/releases/download/v{}/instance-{}.tar.gz", version, arch.brane())
+                format!("https://github.com/braneframework/brane/releases/download/v{}/instance-{}.tar.gz", version, arch.brane())
             };
             debug!("Will download from: {}", address);
 
@@ -258,9 +258,9 @@ pub async fn services(
         DownloadServicesSubcommand::Worker => {
             // Resolve the address to use
             let address: String = if version.is_latest() {
-                format!("https://github.com/epi-project/brane/releases/latest/download/worker-instance-{}.tar.gz", arch.brane())
+                format!("https://github.com/braneframework/brane/releases/latest/download/worker-instance-{}.tar.gz", arch.brane())
             } else {
-                format!("https://github.com/epi-project/brane/releases/download/v{}/worker-instance-{}.tar.gz", version, arch.brane())
+                format!("https://github.com/braneframework/brane/releases/download/v{}/worker-instance-{}.tar.gz", version, arch.brane())
             };
             debug!("Will download from: {}", address);
 

--- a/brane-ctl/src/generate.rs
+++ b/brane-ctl/src/generate.rs
@@ -1329,7 +1329,7 @@ pub async fn policy_database(fix_dirs: bool, path: PathBuf, branch: String) -> R
     }
 
     // Next, fetch the migrations to run
-    debug!("Retrieving up-to-date mitigations from 'https://github.com/epi-project/policy-reasoner ({branch})...");
+    debug!("Retrieving up-to-date mitigations from 'https://github.com/braneframework/policy-reasoner ({branch})...");
     // NOTE: We're not using `_dir`, but keep it to prevent the directory from being removed once the objects gets dropped
     let (_dir, migrations): (TempDir, FileBasedMigrations) = {
         // Prepare the input URL and output directory

--- a/brane-ctl/src/generate.rs
+++ b/brane-ctl/src/generate.rs
@@ -1333,7 +1333,7 @@ pub async fn policy_database(fix_dirs: bool, path: PathBuf, branch: String) -> R
     // NOTE: We're not using `_dir`, but keep it to prevent the directory from being removed once the objects gets dropped
     let (_dir, migrations): (TempDir, FileBasedMigrations) = {
         // Prepare the input URL and output directory
-        let url = format!("https://api.github.com/repos/epi-project/policy-reasoner/tarball/{branch}");
+        let url = format!("https://api.github.com/repos/braneframework/policy-reasoner/tarball/{branch}");
         let dir = match TempDir::new() {
             Ok(dir) => dir,
             Err(err) => {

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -12,7 +12,7 @@ base64 = "0.22.0"
 bollard = "0.18.0"
 chrono = "0.4.35"
 clap = { version = "4.5.6", features = ["derive","env"] }
-deliberation = { git = "https://github.com/epi-project/policy-reasoner" }
+deliberation = { git = "https://github.com/braneframework/policy-reasoner" }
 dotenvy = "0.15.0"
 enum-debug.workspace = true
 env_logger = "0.11.0"

--- a/brane-job/src/worker.rs
+++ b/brane-job/src/worker.rs
@@ -193,7 +193,7 @@ impl error::Error for Error {
 
 
 /***** HELPER STRUCTURES *****/
-/// Manual copy of the [policy-reasoner](https://github.com/epi-project/policy-reasoner)'s `ExecuteTaskRequest`-struct.
+/// Manual copy of the [policy-reasoner](https://github.com/braneframework/policy-reasoner)'s `ExecuteTaskRequest`-struct.
 ///
 /// This is necessary because, when we pull the dependency directly, we get conflicts because that repository depends on the git version of this repository, meaning its notion of a Workflow is always (practically) outdated.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -208,7 +208,7 @@ struct PolicyExecuteRequest {
     pub task_id:  ProgramCounter,
 }
 
-/// Manual copy of the [policy-reasoner](https://github.com/epi-project/policy-reasoner)'s `WorkflowValidationRequest`-struct.
+/// Manual copy of the [policy-reasoner](https://github.com/braneframework/policy-reasoner)'s `WorkflowValidationRequest`-struct.
 ///
 /// This is necessary because, when we pull the dependency directly, we get conflicts because that repository depends on the git version of this repository, meaning its notion of a Workflow is always (practically) outdated.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/brane-prx/Cargo.toml
+++ b/brane-prx/Cargo.toml
@@ -19,7 +19,7 @@ reqwest = { version = "0.12.0", features = ["json"] }
 rustls = "0.21.6"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
-socksx = { git = "https://github.com/epi-project/socksx", tag = "v2.0.0" }
+socksx = { git = "https://github.com/braneframework/socksx", tag = "v2.0.0" }
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-rustls = "0.24.0"
 url = "2.5.0"

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 
 [dependencies]
 clap = { version = "4.5.6", features = ["derive","env"] }
-deliberation = { git = "https://github.com/epi-project/policy-reasoner" }
+deliberation = { git = "https://github.com/braneframework/policy-reasoner" }
 dotenvy = "0.15.0"
 enum-debug.workspace = true
 env_logger = "0.11.0"

--- a/brane-reg/src/data.rs
+++ b/brane-reg/src/data.rs
@@ -226,7 +226,7 @@ pub async fn assert_asset_permission(
 
 
 /***** HELPER STRUCTURES *****/
-/// Manual copy of the [policy-reasoner](https://github.com/epi-project/policy-reasoner)'s `AccessDataRequest`-struct.
+/// Manual copy of the [policy-reasoner](https://github.com/braneframework/policy-reasoner)'s `AccessDataRequest`-struct.
 ///
 /// This is necessary because, when we pull the dependency directly, we get conflicts because that repository depends on the git version of this repository, meaning its notion of a Workflow is always (practically) outdated.
 #[derive(Serialize, Deserialize)]

--- a/tests/packages/copy_result/container.yml
+++ b/tests/packages/copy_result/container.yml
@@ -10,7 +10,7 @@ version: 1.1.0
 kind: ecu
 
 # Provides a brief description
-description: Patchwork package to decouple an input intermediate result from an output result. See https://github.com/epi-project/brane-std.
+description: Patchwork package to decouple an input intermediate result from an output result. See https://github.com/braneframework/brane-std.
 
 # Define the files part of this package
 files:


### PR DESCRIPTION
This does not fork eflint-server-go yet

Also a mention of EPIF-Configurations remains on the epi-project organisation
