### PR TITLE
Fixing more CI problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,6 @@ jobs:
 
     runs-on: ubuntu-24.04
 
-    env:
-      # Disallow warnings
-      RUSTDOCFLAGS: -DWarnings
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/mixin-cargo-build.yml
+++ b/.github/workflows/mixin-cargo-build.yml
@@ -17,6 +17,12 @@ on:
         type: boolean
         default: false
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+
 jobs:
   cargo-build:
     name: "${{ inputs.packages }} / ${{ inputs.os }}"

--- a/.github/workflows/mixin-cargo-check.yml
+++ b/.github/workflows/mixin-cargo-check.yml
@@ -17,6 +17,12 @@ on:
         type: boolean
         default: false
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+
 jobs:
   cargo-check:
     name: "${{ inputs.packages }} / ${{ inputs.os }}"

--- a/.github/workflows/mixin-cargo-clippy.yml
+++ b/.github/workflows/mixin-cargo-clippy.yml
@@ -10,6 +10,12 @@ on:
         required: false
         type: string
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+
 jobs:
   cargo-clippy:
     name: "${{ inputs.os }} / ${{ inputs.rust-version }}"

--- a/.github/workflows/mixin-cargo-test.yml
+++ b/.github/workflows/mixin-cargo-test.yml
@@ -10,6 +10,12 @@ on:
         required: false
         type: string
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+
 jobs:
   cargo-test:
     name: "${{ inputs.os }} / ${{ inputs.rust-version }}"

--- a/brane-ast/src/errors.rs
+++ b/brane-ast/src/errors.rs
@@ -759,7 +759,7 @@ pub enum TypeError {
     NonArrayIndexError { got: DataType, range: TextRange },
 
     /// The user specified something else as a Data than a literal string.
-    DataNameNotAStringError { name: String, got: Expr, range: TextRange },
+    DataNameNotAStringError { name: String, got: Box<Expr>, range: TextRange },
     /// The user did not specify a name field in a Data or IntermediateResult field.
     DataNoNamePropertyError { name: String, range: TextRange },
 }

--- a/brane-exe/src/pc.rs
+++ b/brane-exe/src/pc.rs
@@ -274,7 +274,6 @@ impl Serialize for ProgramCounter {
 impl PartialOrd for ProgramCounter {
     #[inline]
     #[track_caller]
-    #[must_use]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         // Only define an ordering if the functions are the same
         if self.func_id == other.func_id { self.edge_idx.partial_cmp(&other.edge_idx) } else { None }
@@ -292,7 +291,6 @@ impl Add<usize> for ProgramCounter {
     /// A new [`ProgramCounter`] that points to the same function and the same edge index, except the latter is added to `rhs`.
     #[inline]
     #[track_caller]
-    #[must_use]
     fn add(self, rhs: usize) -> Self::Output { Self { func_id: self.func_id, edge_idx: self.edge_idx + rhs } }
 }
 impl AddAssign<usize> for ProgramCounter {

--- a/specifications/src/profiling.rs
+++ b/specifications/src/profiling.rs
@@ -291,7 +291,7 @@ pub struct ProfileScopeHandle<'s> {
 impl ProfileScopeHandle<'static> {
     /// Provides a dummy handle for if you are not interested in profiling, but need to use the functions.
     #[inline]
-    pub fn dummy() -> Self { Self { scope: Arc::new(ProfileScope::new("<<<dummy>>>")), _lifetime: PhantomData::default() } }
+    pub fn dummy() -> Self { Self { scope: Arc::new(ProfileScope::new("<<<dummy>>>")), _lifetime: PhantomData } }
 }
 impl ProfileScopeHandle<'_> {
     /// Finishes a scope, by janking the handle wrapping it out-of-scope.
@@ -465,7 +465,7 @@ impl ProfileScope {
 
         // Create a TimerGuard around that timing.
         let timing: Arc<Mutex<Timing>> = lock.last().unwrap().timing().clone();
-        TimerGuard { start: Instant::now(), timing, _lifetime: PhantomData::default() }
+        TimerGuard { start: Instant::now(), timing, _lifetime: PhantomData }
     }
 
     /// Profiles the given function and adds its timing under the given name.
@@ -540,7 +540,7 @@ impl ProfileScope {
         lock.push(ProfileTiming::Scope(Arc::new(scope)));
 
         // Return a weak reference to it
-        ProfileScopeHandle { scope: lock.last().unwrap().scope().clone(), _lifetime: PhantomData::default() }
+        ProfileScopeHandle { scope: lock.last().unwrap().scope().clone(), _lifetime: PhantomData }
     }
 
     /// Profiles the given function, but provides it with extra profile options by giving it its own `ProfileScope` to populate.

--- a/specifications/src/profiling.rs
+++ b/specifications/src/profiling.rs
@@ -455,7 +455,7 @@ impl ProfileScope {
     /// - `name`: The name to set for this Timing.
     ///
     /// # Returns
-    /// A new [`Timer`] struct to take a timing.
+    /// A new [`TimerGuard`] struct to take a timing.
     pub fn time(&self, name: impl Into<String>) -> TimerGuard {
         // Get a lock
         let mut lock: MutexGuard<Vec<ProfileTiming>> = self.timings.lock();


### PR DESCRIPTION
From the documentation:
> Any environment variables set in an env context defined at the workflow
> level in the caller workflow are not propagated to the called workflow.
> For more information, see Store information in variables and Accessing
> contextual information about workflow runs.