### PR TITLE
Use thiserror for Errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "serde_yml",
  "specifications 3.0.0",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "serde_json",
  "serde_json_any_key",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "specifications 3.0.0",
  "tar",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "serde_yml",
  "sha2",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-tar",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
  "sha2",
  "specifications 3.0.0",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "specifications 3.0.0",
  "srv",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "log",
  "serde_json",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "serde_json_any_key",
  "specifications 3.0.0",
  "strum 0.27.1",
+ "thiserror 2.0.12",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "serde_json_any_key",
  "serde_yml",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "serde",
  "serde_yml",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "x509-parser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "serde_json",
  "socksx",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls 0.24.1",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "serde_yml",
  "specifications 3.0.0",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls 0.24.1",
  "warp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
  "tonic 0.12.3",
  "yaml-rust2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,6 +4406,7 @@ dependencies = [
  "serde_yml",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "thiserror 2.0.12",
  "tonic 0.12.3",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "regex",
  "serde",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specifications 3.0.0",
+ "thiserror 2.0.12",
  "tokio",
 ]
 

--- a/brane-api/Cargo.toml
+++ b/brane-api/Cargo.toml
@@ -27,6 +27,7 @@ scylla = "0.12.0"
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tempfile = "3.10.1"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"

--- a/brane-api/src/errors.rs
+++ b/brane-api/src/errors.rs
@@ -12,8 +12,6 @@
 //!   Contains general errors for across the brane-api package.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::path::PathBuf;
 
 use brane_cfg::node::NodeKind;
@@ -27,262 +25,201 @@ use specifications::version::Version;
 
 /***** ERRORS *****/
 /// Collects errors for the most general case in the brane-api package
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ApiError {
     /// Could not create a Scylla session
-    ScyllaConnectError { host: Address, err: NewSessionError },
+    #[error("Could not connect to Scylla host '{host}'")]
+    ScyllaConnectError { host: Address, source: NewSessionError },
 }
-
-impl Display for ApiError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        match self {
-            ApiError::ScyllaConnectError { host, err } => write!(f, "Could not connect to Scylla host '{host}': {err}"),
-        }
-    }
-}
-
-impl Error for ApiError {}
-
 
 
 /// Contains errors relating to the `/infra` path (and nested).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum InfraError {
     /// Failed to open/load the infrastructure file.
-    InfrastructureOpenError { path: PathBuf, err: brane_cfg::infra::Error },
+    #[error("Failed to open infrastructure file '{}'", path.display())]
+    InfrastructureOpenError { path: PathBuf, source: brane_cfg::infra::Error },
     /// Failed to serialize the response body.
-    SerializeError { what: &'static str, err: serde_json::Error },
+    #[error("Failed to serialize {what}")]
+    SerializeError { what: &'static str, source: serde_json::Error },
 
     /// Failed to do the proxy redirection thing.
-    ProxyError { err: brane_prx::errors::ClientError },
+    #[error("Failed to send request through Brane proxy service")]
+    ProxyError { source: brane_prx::errors::ClientError },
     /// Failed to send a request to the given address.
-    RequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send GET-request to '{address}'")]
+    RequestError { address: String, source: reqwest::Error },
     /// The request was not met with an OK
+    #[error(
+        "Request to '{}' failed with status code {} ({}){}",
+        address,
+        code,
+        code.canonical_reason().unwrap_or("???"),
+        if let Some(err) = message { format!(": {err}") } else { String::new() }
+    )]
     RequestFailure { address: String, code: StatusCode, message: Option<String> },
     /// Failed to read the body sent by the other domain.
-    ResponseBodyError { address: String, err: reqwest::Error },
+    #[error("Failed to get body of response sent by '{address}'")]
+    ResponseBodyError { address: String, source: reqwest::Error },
     /// Failed to parse the body as JSON
-    ResponseParseError { address: String, raw: String, err: serde_json::Error },
+    #[error("Failed to parse '{raw}' as valid JSON sent by '{address}'")]
+    ResponseParseError { address: String, raw: String, source: serde_json::Error },
     /// Failed to re-serialize the parsed body
-    CapabilitiesSerializeError { err: serde_json::Error },
+    #[error("Failed to re-serialize capabilities")]
+    CapabilitiesSerializeError { source: serde_json::Error },
 
     /// An internal error occurred that we would not like to divulge.
+    #[error("An internal error has occurred")]
     SecretError,
 }
-
-impl Display for InfraError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use InfraError::*;
-        match self {
-            InfrastructureOpenError { path, err } => write!(f, "Failed to open infrastructure file '{}': {}", path.display(), err),
-            SerializeError { what, err } => write!(f, "Failed to serialize {what}: {err}"),
-
-            ProxyError { err } => write!(f, "Failed to send request through Brane proxy service: {err}"),
-            RequestError { address, err } => write!(f, "Failed to send GET-request to '{address}': {err}"),
-            RequestFailure { address, code, message } => write!(
-                f,
-                "Request to '{}' failed with status code {} ({}){}",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(err) = message { format!(": {err}") } else { String::new() }
-            ),
-            ResponseBodyError { address, err } => write!(f, "Failed to get body of response sent by '{address}': {err}"),
-            ResponseParseError { address, raw, err } => write!(f, "Failed to parse '{raw}' as valid JSON sent by '{address}': {err}"),
-            CapabilitiesSerializeError { err } => write!(f, "Failed to re-serialize capabilities: {err}"),
-
-            SecretError => write!(f, "An internal error has occurred"),
-        }
-    }
-}
-
-impl Error for InfraError {}
 
 impl warp::reject::Reject for InfraError {}
 
 
 
 /// Contains errors relating to the `/data` path (and nested).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DataError {
     /// Failed to open/load the infrastructure file.
-    InfrastructureOpenError { path: PathBuf, err: brane_cfg::infra::Error },
+    #[error("Failed to open infrastructure file '{}'", path.display())]
+    InfrastructureOpenError { path: PathBuf, source: brane_cfg::infra::Error },
     /// Failed to get the list of all locations.
-    InfrastructureLocationsError { path: PathBuf, err: brane_cfg::infra::Error },
+    #[error("Failed to get locations from infrastructure file '{}'", path.display())]
+    InfrastructureLocationsError { path: PathBuf, source: brane_cfg::infra::Error },
     /// Failed to get the metadata of a location.
-    InfrastructureMetadataError { path: PathBuf, name: String, err: brane_cfg::infra::Error },
+    #[error("Failed to get metadata of location '{}' from infrastructure file '{}'", name, path.display())]
+    InfrastructureMetadataError { path: PathBuf, name: String, source: brane_cfg::infra::Error },
 
     /// Failed to create a new port on the proxy.
-    ProxyError { err: brane_prx::client::Error },
+    #[error("Failed to prepare sending a request using the proxy service")]
+    ProxyError { source: brane_prx::client::Error },
     /// Failed to send a GET-request to the given URL
-    RequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send GET-request to '{address}'")]
+    RequestError { address: String, source: reqwest::Error },
     /// Failed to get the body of a response.
-    ResponseBodyError { address: String, err: reqwest::Error },
+    #[error("Failed to get the response body received from '{address}'")]
+    ResponseBodyError { address: String, source: reqwest::Error },
     /// Failed to parse the body of a response.
-    ResponseParseError { address: String, err: serde_json::Error },
+    #[error("Failed to parse response from '{address}' as JSON")]
+    ResponseParseError { address: String, source: serde_json::Error },
     /// Failed to serialize the response body.
-    SerializeError { what: &'static str, err: serde_json::Error },
+    #[error("Failed to serialize {what}")]
+    SerializeError { what: &'static str, source: serde_json::Error },
 
     /// An internal error occurred that we would not like to divulge.
+    #[error("An internal error has occurred")]
     SecretError,
 }
 
-impl Display for DataError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DataError::*;
-        match self {
-            InfrastructureOpenError { path, err } => write!(f, "Failed to open infrastructure file '{}': {}", path.display(), err),
-            InfrastructureLocationsError { path, err } => write!(f, "Failed to get locations from infrastructure file '{}': {}", path.display(), err),
-            InfrastructureMetadataError { path, name, err } => {
-                write!(f, "Failed to get metadata of location '{}' from infrastructure file '{}': {}", name, path.display(), err)
-            },
-
-            ProxyError { err } => write!(f, "Failed to prepare sending a request using the proxy service: {err}"),
-            RequestError { address, err } => write!(f, "Failed to send GET-request to '{address}': {err}"),
-            ResponseBodyError { address, err } => write!(f, "Failed to get the response body received from '{address}': {err}"),
-            ResponseParseError { address, err } => write!(f, "Failed to parse response from '{address}' as JSON: {err}"),
-            SerializeError { what, err } => write!(f, "Failed to serialize {what}: {err}"),
-
-            SecretError => write!(f, "An internal error has occurred"),
-        }
-    }
-}
-
-impl Error for DataError {}
 
 impl warp::reject::Reject for DataError {}
 
-
-
 /// Contains errors relating to the `/packages` path (and nested).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PackageError {
     /// Failed to serialize the funcitions in a PackageInfo.
-    FunctionsSerializeError { name: String, err: serde_json::Error },
+    #[error("Failed to serialize functions in package '{name}'")]
+    FunctionsSerializeError { name: String, source: serde_json::Error },
     /// Failed to serialize the types in a PackageInfo.
-    TypesSerializeError { name: String, err: serde_json::Error },
+    #[error("Failed to serialize types in package '{name}'")]
+    TypesSerializeError { name: String, source: serde_json::Error },
     /// The given PackageInfo did not have a digest registered.
+    #[error("Package '{name}' does not have a digest specified")]
     MissingDigest { name: String },
 
     /// Failed to define the `brane.package` type in the Scylla database.
-    PackageTypeDefineError { err: scylla::transport::errors::QueryError },
+    #[error("Failed to define the 'brane.package' type in the Scylla database")]
+    PackageTypeDefineError { source: scylla::transport::errors::QueryError },
     /// Failed to define the package table in the Scylla database.
-    PackageTableDefineError { err: scylla::transport::errors::QueryError },
+    #[error("Failed to define the 'brane.packages' table in the Scylla database")]
+    PackageTableDefineError { source: scylla::transport::errors::QueryError },
     /// Failed to insert a new package in the database.
-    PackageInsertError { name: String, err: scylla::transport::errors::QueryError },
+    #[error("Failed to insert package '{name}' into the Scylla database")]
+    PackageInsertError { name: String, source: scylla::transport::errors::QueryError },
 
     /// Failed to query for the given package in the Scylla database.
-    VersionsQueryError { name: String, err: scylla::transport::errors::QueryError },
+    #[error("Failed to query versions for package '{name}' from the Scylla database")]
+    VersionsQueryError { name: String, source: scylla::transport::errors::QueryError },
     /// Failed to parse a Version string
-    VersionParseError { raw: String, err: specifications::version::ParseError },
+    #[error("Failed to parse '{raw}' as a valid version string")]
+    VersionParseError { raw: String, source: specifications::version::ParseError },
     /// No versions found for the given package
+    #[error("No versions found for package '{name}'")]
     NoVersionsFound { name: String },
     /// Failed to query the database for the file of the given package.
-    PathQueryError { name: String, version: Version, err: scylla::transport::errors::QueryError },
+    #[error("Failed to get path of package '{name}', version {version}")]
+    PathQueryError { name: String, version: Version, source: scylla::transport::errors::QueryError },
     /// The given package was unknown.
+    #[error("No package '{name}' exists (or has version {version})")]
     UnknownPackage { name: String, version: Version },
     /// Failed to get the metadata of a file.
-    FileMetadataError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to get metadata of file '{}'", path.display())]
+    FileMetadataError { path: PathBuf, source: std::io::Error },
     /// Failed to open a file.
-    FileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open file '{}'", path.display())]
+    FileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read a file.
-    FileReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read file '{}'", path.display())]
+    FileReadError { path: PathBuf, source: std::io::Error },
     /// Failed to send a file chunk.
-    FileSendError { path: PathBuf, err: warp::hyper::Error },
+    #[error("Failed to send chunk of file '{}'", path.display())]
+    FileSendError { path: PathBuf, source: warp::hyper::Error },
 
     /// Failed to load the node config.
-    NodeConfigLoadError { err: brane_cfg::info::YamlError },
+    #[error("Failed to load node config file")]
+    NodeConfigLoadError { source: brane_cfg::info::YamlError },
     /// The given node config was not for central nodes.
+    #[error("Given node config file '{}' is for a {} node, but expected a {} node", path.display(), got.variant(), expected.variant())]
     NodeConfigUnexpectedKind { path: PathBuf, got: NodeKind, expected: NodeKind },
     /// Failed to create a temporary directory.
-    TempDirCreateError { err: std::io::Error },
+    #[error("Failed to create temporary directory")]
+    TempDirCreateError { source: std::io::Error },
     /// Failed to create a particular file.
-    TarCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create new tar file '{}'", path.display())]
+    TarCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to read the next chunk in the body stream.
-    BodyReadError { err: warp::Error },
+    #[error("Failed to get next chunk in body stream")]
+    BodyReadError { source: warp::Error },
     /// Failed to write a chunk to a particular tar file.
-    TarWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write body chunk to tar file '{}'", path.display())]
+    TarWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to flush the tarfile handle.
-    TarFlushError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to flush new far file '{}'", path.display())]
+    TarFlushError { path: PathBuf, source: std::io::Error },
     /// Failed to re-open the downloaded tarfile to extract it.
-    TarReopenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to re-open new tar file '{}'", path.display())]
+    TarReopenError { path: PathBuf, source: std::io::Error },
     /// Failed to get the list of entries in the tar file.
-    TarEntriesError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to get list of entries in tar file '{}'", path.display())]
+    TarEntriesError { path: PathBuf, source: std::io::Error },
     /// Failed to get a single entry in the entries of a tar file.
-    TarEntryError { path: PathBuf, entry: usize, err: std::io::Error },
+    #[error("Failed to get entry {} in tar file '{}'", entry, path.display())]
+    TarEntryError { path: PathBuf, entry: usize, source: std::io::Error },
     /// The given tar file had less entries than we expected.
+    #[error("Tar file '{}' has only {} entries, but expected {}", path.display(), expected, got)]
     TarNotEnoughEntries { path: PathBuf, expected: usize, got: usize },
     /// The given tar file had too many entries.
+    #[error("Tar file '{}' has more than {} entries", path.display(), expected)]
     TarTooManyEntries { path: PathBuf, expected: usize },
     /// Failed to get the path of an entry.
-    TarEntryPathError { path: PathBuf, entry: usize, err: std::io::Error },
+    #[error("Failed to get the path of entry {} in tar file '{}'", entry, path.display())]
+    TarEntryPathError { path: PathBuf, entry: usize, source: std::io::Error },
     /// The given tar file is missing expected entries.
+    #[error("Tar file '{}' does not have entries {}", path.display(), PrettyListFormatter::new(expected.iter(), "or"))]
     TarMissingEntries { expected: Vec<&'static str>, path: PathBuf },
     /// Failed to properly close the tar file.
+    #[error("Failed to close tar file '{}'", path.display())]
     TarFileCloseError { path: PathBuf },
     /// Failed to unpack the given image file.
-    TarFileUnpackError { file: PathBuf, tarball: PathBuf, target: PathBuf, err: std::io::Error },
+    #[error("Failed to extract '{}' file from tar file '{}' to '{}'", file.display(), tarball.display(), target.display())]
+    TarFileUnpackError { file: PathBuf, tarball: PathBuf, target: PathBuf, source: std::io::Error },
     /// Failed to read the extracted package info file.
-    PackageInfoReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read extracted package info file '{}'", path.display())]
+    PackageInfoReadError { path: PathBuf, source: std::io::Error },
     /// Failed to parse the extracted package info file.
-    PackageInfoParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse extracted package info file '{}' as YAML", path.display())]
+    PackageInfoParseError { path: PathBuf, source: serde_yaml::Error },
     /// Failed to move the temporary image to its final destination.
-    FileMoveError { from: PathBuf, to: PathBuf, err: std::io::Error },
+    #[error("Failed to move '{}' to '{}'", from.display(), to.display())]
+    FileMoveError { from: PathBuf, to: PathBuf, source: std::io::Error },
 }
-
-impl Display for PackageError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use PackageError::*;
-        match self {
-            FunctionsSerializeError { name, err } => write!(f, "Failed to serialize functions in package '{name}': {err}"),
-            TypesSerializeError { name, err } => write!(f, "Failed to serialize types in package '{name}': {err}"),
-            MissingDigest { name } => write!(f, "Package '{name}' does not have a digest specified"),
-
-            PackageTypeDefineError { err } => write!(f, "Failed to define the 'brane.package' type in the Scylla database: {err}"),
-            PackageTableDefineError { err } => write!(f, "Failed to define the 'brane.packages' table in the Scylla database: {err}"),
-            PackageInsertError { name, err } => write!(f, "Failed to insert package '{name}' into the Scylla database: {err}"),
-
-            VersionsQueryError { name, err } => write!(f, "Failed to query versions for package '{name}' from the Scylla database: {err}"),
-            VersionParseError { raw, err } => write!(f, "Failed to parse '{raw}' as a valid version string: {err}"),
-            NoVersionsFound { name } => write!(f, "No versions found for package '{name}'"),
-            PathQueryError { name, version, err } => write!(f, "Failed to get path of package '{name}', version {version}: {err}"),
-            UnknownPackage { name, version } => write!(f, "No package '{name}' exists (or has version {version})"),
-            FileMetadataError { path, err } => write!(f, "Failed to get metadata of file '{}': {}", path.display(), err),
-            FileOpenError { path, err } => write!(f, "Failed to open file '{}': {}", path.display(), err),
-            FileReadError { path, err } => write!(f, "Failed to read file '{}': {}", path.display(), err),
-            FileSendError { path, err } => write!(f, "Failed to send chunk of file '{}': {}", path.display(), err),
-
-            NodeConfigLoadError { err } => write!(f, "Failed to load node config file: {err}"),
-            NodeConfigUnexpectedKind { path, got, expected } => {
-                write!(f, "Given node config file '{}' is for a {} node, but expected a {} node", path.display(), got.variant(), expected.variant())
-            },
-            TempDirCreateError { err } => write!(f, "Failed to create temporary directory: {err}"),
-            TarCreateError { path, err } => write!(f, "Failed to create new tar file '{}': {}", path.display(), err),
-            BodyReadError { err } => write!(f, "Failed to get next chunk in body stream: {err}"),
-            TarWriteError { path, err } => write!(f, "Failed to write body chunk to tar file '{}': {}", path.display(), err),
-            TarFlushError { path, err } => write!(f, "Failed to flush new far file '{}': {}", path.display(), err),
-            TarReopenError { path, err } => write!(f, "Failed to re-open new tar file '{}': {}", path.display(), err),
-            TarEntriesError { path, err } => write!(f, "Failed to get list of entries in tar file '{}': {}", path.display(), err),
-            TarEntryError { path, entry, err } => write!(f, "Failed to get entry {} in tar file '{}': {}", entry, path.display(), err),
-            TarNotEnoughEntries { path, expected, got } => {
-                write!(f, "Tar file '{}' has only {} entries, but expected {}", path.display(), expected, got)
-            },
-            TarTooManyEntries { path, expected } => write!(f, "Tar file '{}' has more than {} entries", path.display(), expected),
-            TarEntryPathError { path, entry, err } => {
-                write!(f, "Failed to get the path of entry {} in tar file '{}': {}", entry, path.display(), err)
-            },
-            TarMissingEntries { expected, path } => {
-                write!(f, "Tar file '{}' does not have entries {}", path.display(), PrettyListFormatter::new(expected.iter(), "or"))
-            },
-            TarFileCloseError { path } => write!(f, "Failed to close tar file '{}'", path.display()),
-            TarFileUnpackError { file, tarball, target, err } => {
-                write!(f, "Failed to extract '{}' file from tar file '{}' to '{}': {}", file.display(), tarball.display(), target.display(), err)
-            },
-            PackageInfoReadError { path, err } => write!(f, "Failed to read extracted package info file '{}': {}", path.display(), err),
-            PackageInfoParseError { path, err } => write!(f, "Failed to parse extracted package info file '{}' as YAML: {}", path.display(), err),
-            FileMoveError { from, to, err } => write!(f, "Failed to move '{}' to '{}': {}", from.display(), to.display(), err),
-        }
-    }
-}
-
-impl Error for PackageError {}

--- a/brane-api/src/infra.rs
+++ b/brane-api/src/infra.rs
@@ -59,8 +59,8 @@ pub async fn registries(context: Context) -> Result<impl Reply, Rejection> {
     // Load the infrastructure file
     let infra: InfraFile = match InfraFile::from_path(&node_config.node.central().paths.infra) {
         Ok(infra) => infra,
-        Err(err) => {
-            error!("{}", Error::InfrastructureOpenError { path: node_config.node.central().paths.infra.clone(), err });
+        Err(source) => {
+            error!("{}", Error::InfrastructureOpenError { path: node_config.node.central().paths.infra.clone(), source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
@@ -74,8 +74,8 @@ pub async fn registries(context: Context) -> Result<impl Reply, Rejection> {
     // Now serialize this map
     let body: String = match serde_json::to_string(&locations) {
         Ok(body) => body,
-        Err(err) => {
-            error!("{}", Error::SerializeError { what: "list of all registry endpoints", err });
+        Err(source) => {
+            error!("{}", Error::SerializeError { what: "list of all registry endpoints", source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
@@ -121,8 +121,8 @@ pub async fn get_registry(loc: String, context: Context) -> Result<impl Reply, R
     // Load the infrastructure file
     let infra: InfraFile = match InfraFile::from_path(&node_config.node.central().paths.infra) {
         Ok(infra) => infra,
-        Err(err) => {
-            error!("{}", Error::InfrastructureOpenError { path: node_config.node.central().paths.infra.clone(), err });
+        Err(source) => {
+            error!("{}", Error::InfrastructureOpenError { path: node_config.node.central().paths.infra.clone(), source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
@@ -179,8 +179,8 @@ pub async fn get_capabilities(loc: String, context: Context) -> Result<impl Repl
     // Load the infrastructure file
     let infra: InfraFile = match InfraFile::from_path(&node_config.node.central().paths.infra) {
         Ok(infra) => infra,
-        Err(err) => {
-            error!("{}", Error::InfrastructureOpenError { path: node_config.node.central().paths.infra.clone(), err });
+        Err(source) => {
+            error!("{}", Error::InfrastructureOpenError { path: node_config.node.central().paths.infra.clone(), source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
@@ -198,13 +198,13 @@ pub async fn get_capabilities(loc: String, context: Context) -> Result<impl Repl
     let res: reqwest::Response = match context.proxy.get(&reg_addr, Some(NewPathRequestTlsOptions { use_client_auth: false, location: loc })).await {
         Ok(res) => match res {
             Ok(res) => res,
-            Err(err) => {
-                error!("{}", Error::RequestError { address: reg_addr, err });
+            Err(source) => {
+                error!("{}", Error::RequestError { address: reg_addr, source });
                 return Err(warp::reject::custom(Error::SecretError));
             },
         },
-        Err(err) => {
-            error!("{}", Error::ProxyError { err });
+        Err(source) => {
+            error!("{}", Error::ProxyError { source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
@@ -216,15 +216,15 @@ pub async fn get_capabilities(loc: String, context: Context) -> Result<impl Repl
     // Parse the body as the proper JSON
     let capabilities: String = match res.text().await {
         Ok(caps) => caps,
-        Err(err) => {
-            error!("{}", Error::ResponseBodyError { address: reg_addr, err });
+        Err(source) => {
+            error!("{}", Error::ResponseBodyError { address: reg_addr, source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
     let capabilities: HashSet<Capability> = match serde_json::from_str(&capabilities) {
         Ok(caps) => caps,
-        Err(err) => {
-            error!("{}", Error::ResponseParseError { address: reg_addr, raw: capabilities, err });
+        Err(source) => {
+            error!("{}", Error::ResponseParseError { address: reg_addr, raw: capabilities, source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };
@@ -232,8 +232,8 @@ pub async fn get_capabilities(loc: String, context: Context) -> Result<impl Repl
     // Create a body with the registry (re-serialize for full correctness)
     let body: String = match serde_json::to_string(&capabilities) {
         Ok(body) => body,
-        Err(err) => {
-            error!("{}", Error::CapabilitiesSerializeError { err });
+        Err(source) => {
+            error!("{}", Error::CapabilitiesSerializeError { source });
             return Err(warp::reject::custom(Error::SecretError));
         },
     };

--- a/brane-api/src/main.rs
+++ b/brane-api/src/main.rs
@@ -101,7 +101,7 @@ async fn main() {
     {
         Ok(scylla) => scylla,
         Err(reason) => {
-            error!("{}", ApiError::ScyllaConnectError { host: central.services.aux_scylla.address, err: reason });
+            error!("{}", ApiError::ScyllaConnectError { host: central.services.aux_scylla.address, source: reason });
             std::process::exit(-1);
         },
     };

--- a/brane-api/src/packages.rs
+++ b/brane-api/src/packages.rs
@@ -149,7 +149,7 @@ impl TryFrom<PackageInfo> for PackageUdt {
 /// This function errors if the communication with the given database failed too.
 pub async fn ensure_db_table(scylla: &Session) -> Result<(), Error> {
     // Define the `brane.package` type
-    if let Err(err) = scylla
+    scylla
         .query(
             "CREATE TYPE IF NOT EXISTS brane.package (
                 created bigint
@@ -170,7 +170,7 @@ pub async fn ensure_db_table(scylla: &Session) -> Result<(), Error> {
         .map_err(|source| Error::PackageTypeDefineError { source })?;
 
     // Define  the `brane.packages` table
-    if let Err(err) = scylla
+    scylla
         .query(
             "CREATE TABLE IF NOT EXISTS brane.packages (
               name text
@@ -209,7 +209,7 @@ async fn insert_package_into_db(scylla: &Arc<Session>, package: &PackageInfo, pa
     let package: PackageUdt = package.clone().try_into()?;
 
     // Insert it
-    if let Err(err) = scylla
+    scylla
         .query(
             "INSERT INTO brane.packages (
               name

--- a/brane-api/src/packages.rs
+++ b/brane-api/src/packages.rs
@@ -107,26 +107,13 @@ impl TryFrom<PackageInfo> for PackageUdt {
 
     fn try_from(package: PackageInfo) -> Result<Self, Self::Error> {
         // First, serialize the functions and the types as JSON
-        let functions_as_json: String = match serde_json::to_string(&package.functions) {
-            Ok(funcs) => funcs,
-            Err(err) => {
-                return Err(Error::FunctionsSerializeError { name: package.name, err });
-            },
-        };
-        let types_as_json: String = match serde_json::to_string(&package.types) {
-            Ok(types) => types,
-            Err(err) => {
-                return Err(Error::TypesSerializeError { name: package.name, err });
-            },
-        };
+        let functions_as_json: String =
+            serde_json::to_string(&package.functions).map_err(|source| Error::FunctionsSerializeError { name: package.name.clone(), source })?;
+        let types_as_json: String =
+            serde_json::to_string(&package.types).map_err(|source| Error::TypesSerializeError { name: package.name.clone(), source })?;
 
         // Assert that there is a digest
-        let digest: String = match package.digest {
-            Some(digest) => digest,
-            None => {
-                return Err(Error::MissingDigest { name: package.name });
-            },
-        };
+        let digest: String = package.digest.ok_or_else(|| Error::MissingDigest { name: package.name.clone() })?;
 
         // We can then simply populate the package info
         Ok(Self {
@@ -180,9 +167,7 @@ pub async fn ensure_db_table(scylla: &Session) -> Result<(), Error> {
             &[],
         )
         .await
-    {
-        return Err(Error::PackageTypeDefineError { err });
-    }
+        .map_err(|source| Error::PackageTypeDefineError { source })?;
 
     // Define  the `brane.packages` table
     if let Err(err) = scylla
@@ -197,9 +182,7 @@ pub async fn ensure_db_table(scylla: &Session) -> Result<(), Error> {
             &[],
         )
         .await
-    {
-        return Err(Error::PackageTableDefineError { err });
-    }
+        .map_err(|source| Error::PackageTableDefineError { source })?;
 
     // Done
     Ok(())
@@ -238,9 +221,7 @@ async fn insert_package_into_db(scylla: &Arc<Session>, package: &PackageInfo, pa
             (&package.name, &package.version, path.to_string_lossy().to_string(), &package),
         )
         .await
-    {
-        return Err(Error::PackageInsertError { name: package.name, err });
-    }
+        .map_err(|source| Error::PackageInsertError { name: package.name, source })?;
 
     // Done
     Ok(())
@@ -271,8 +252,8 @@ pub async fn download(name: String, version: String, context: Context) -> Result
     let version: Version = if version.to_lowercase() == "latest" {
         let versions = match context.scylla.query("SELECT version FROM brane.packages WHERE name=?", vec![&name]).await {
             Ok(versions) => versions,
-            Err(err) => {
-                fail!(Error::VersionsQueryError { name, err });
+            Err(source) => {
+                fail!(Error::VersionsQueryError { name, source });
             },
         };
         let mut latest: Option<Version> = None;
@@ -284,8 +265,8 @@ pub async fn download(name: String, version: String, context: Context) -> Result
                 // Attempt to parse
                 let version: Version = match Version::from_str(version) {
                     Ok(version) => version,
-                    Err(err) => {
-                        fail!(Error::VersionParseError { raw: version.into(), err });
+                    Err(source) => {
+                        fail!(Error::VersionParseError { raw: version.into(), source });
                     },
                 };
 
@@ -307,8 +288,8 @@ pub async fn download(name: String, version: String, context: Context) -> Result
     } else {
         match Version::from_str(&version) {
             Ok(version) => version,
-            Err(err) => {
-                fail!(Error::VersionParseError { raw: version, err });
+            Err(source) => {
+                fail!(Error::VersionParseError { raw: version, source });
             },
         }
     };
@@ -332,16 +313,16 @@ pub async fn download(name: String, version: String, context: Context) -> Result
                     return Err(warp::reject::not_found());
                 }
             },
-            Err(err) => {
-                fail!(Error::PathQueryError { name, version, err });
+            Err(source) => {
+                fail!(Error::PathQueryError { name, version, source });
             },
         };
 
     // Retrieve the size of the file for the content length
     let length: u64 = match tfs::metadata(&file).await {
         Ok(metadata) => metadata.len(),
-        Err(err) => {
-            fail!(Error::FileMetadataError { path: file, err });
+        Err(source) => {
+            fail!(Error::FileMetadataError { path: file, source });
         },
     };
 
@@ -354,8 +335,8 @@ pub async fn download(name: String, version: String, context: Context) -> Result
         // Open the archive file to read
         let mut handle: tfs::File = match tfs::File::open(&file).await {
             Ok(handle) => handle,
-            Err(err) => {
-                fail!(Error::FileOpenError { path: file, err });
+            Err(source) => {
+                fail!(Error::FileOpenError { path: file, source });
             },
         };
 
@@ -366,8 +347,8 @@ pub async fn download(name: String, version: String, context: Context) -> Result
             // Read the chunk
             let bytes: usize = match handle.read(&mut buf).await {
                 Ok(bytes) => bytes,
-                Err(err) => {
-                    fail!(Error::FileReadError { path: file, err });
+                Err(source) => {
+                    fail!(Error::FileReadError { path: file, source });
                 },
             };
             if bytes == 0 {
@@ -375,8 +356,8 @@ pub async fn download(name: String, version: String, context: Context) -> Result
             }
 
             // Send that with the body
-            if let Err(err) = body_sender.send_data(Bytes::copy_from_slice(&buf[..bytes])).await {
-                fail!(Error::FileSendError { path: file, err });
+            if let Err(source) = body_sender.send_data(Bytes::copy_from_slice(&buf[..bytes])).await {
+                fail!(Error::FileSendError { path: file, source });
             }
         }
 
@@ -416,8 +397,8 @@ where
     // Load the node config file
     let node_config: NodeConfig = match NodeConfig::from_path(&context.node_config_path) {
         Ok(config) => config,
-        Err(err) => {
-            fail!(Error::NodeConfigLoadError { err });
+        Err(source) => {
+            fail!(Error::NodeConfigLoadError { source });
         },
     };
     let central: &CentralConfig = match node_config.node.try_central() {
@@ -438,8 +419,8 @@ where
     debug!("Preparing filesystem...");
     let tempdir: TempDir = match TempDir::new() {
         Ok(tempdir) => tempdir,
-        Err(err) => {
-            fail!(Error::TempDirCreateError { err });
+        Err(source) => {
+            fail!(Error::TempDirCreateError { source });
         },
     };
     let tempdir_path: &Path = tempdir.path();
@@ -451,8 +432,8 @@ where
     let tar_path: PathBuf = tempdir_path.join(format!("{id}.tar.gz"));
     let mut handle = match tfs::File::create(&tar_path).await {
         Ok(handle) => handle,
-        Err(err) => {
-            fail!(Error::TarCreateError { path: tar_path, err });
+        Err(source) => {
+            fail!(Error::TarCreateError { path: tar_path, source });
         },
     };
 
@@ -462,20 +443,20 @@ where
         // Unwrap the chunk
         let mut chunk: B = match chunk {
             Ok(chunk) => chunk,
-            Err(err) => {
-                fail!(Error::BodyReadError { err });
+            Err(source) => {
+                fail!(Error::BodyReadError { source });
             },
         };
 
         // Write the chunk to the Tokio file
-        if let Err(err) = handle.write_all_buf(&mut chunk).await {
-            fail!(Error::TarWriteError { path: tar_path, err });
+        if let Err(source) = handle.write_all_buf(&mut chunk).await {
+            fail!(Error::TarWriteError { path: tar_path, source });
         }
     }
 
     // Wait until the handle is finished writing
-    if let Err(err) = handle.shutdown().await {
-        fail!(Error::TarFlushError { path: tar_path, err });
+    if let Err(source) = handle.shutdown().await {
+        fail!(Error::TarFlushError { path: tar_path, source });
     }
 
 
@@ -488,8 +469,8 @@ where
     {
         let handle: tfs::File = match tfs::File::open(&tar_path).await {
             Ok(handle) => handle,
-            Err(err) => {
-                fail!(Error::TarReopenError { path: tar_path, err });
+            Err(source) => {
+                fail!(Error::TarReopenError { path: tar_path, source });
             },
         };
 
@@ -500,8 +481,8 @@ where
         // Iterate over the entries in the stream
         let mut entries: Entries<_> = match tar.entries() {
             Ok(entries) => entries,
-            Err(err) => {
-                fail!(Error::TarEntriesError { path: tar_path, err });
+            Err(source) => {
+                fail!(Error::TarEntriesError { path: tar_path, source });
             },
         };
         let mut i: usize = 0;
@@ -511,16 +492,16 @@ where
             // Unwrap the entry
             let mut entry: Entry<_> = match entry {
                 Ok(entry) => entry,
-                Err(err) => {
-                    fail!(Error::TarEntryError { path: tar_path, entry: i, err });
+                Err(source) => {
+                    fail!(Error::TarEntryError { path: tar_path, entry: i, source });
                 },
             };
 
             // Attempt to get its path
             let entry_path: Cow<Path> = match entry.path() {
                 Ok(path) => path,
-                Err(err) => {
-                    fail!(Error::TarEntryPathError { path: tar_path, entry: i, err });
+                Err(source) => {
+                    fail!(Error::TarEntryPathError { path: tar_path, entry: i, source });
                 },
             };
 
@@ -528,15 +509,15 @@ where
             if entry_path == PathBuf::from("package.yml") {
                 // Extract as such
                 debug!("Extracting '{}/package.yml' to '{}'...", tar_path.display(), info_path.display());
-                if let Err(err) = entry.unpack(&info_path).await {
-                    fail!(Error::TarFileUnpackError { file: PathBuf::from("package.yml"), tarball: tar_path, target: info_path, err });
+                if let Err(source) = entry.unpack(&info_path).await {
+                    fail!(Error::TarFileUnpackError { file: PathBuf::from("package.yml"), tarball: tar_path, target: info_path, source });
                 }
                 did_info = true;
             } else if entry_path == PathBuf::from("image.tar") {
                 // Extract as such
                 debug!("Extracting '{}/image.tar' to '{}'...", tar_path.display(), image_path.display());
-                if let Err(err) = entry.unpack(&image_path).await {
-                    fail!(Error::TarFileUnpackError { file: PathBuf::from("image.tar"), tarball: tar_path, target: image_path, err });
+                if let Err(source) = entry.unpack(&image_path).await {
+                    fail!(Error::TarFileUnpackError { file: PathBuf::from("image.tar"), tarball: tar_path, target: image_path, source });
                 }
                 did_image = true;
             } else {
@@ -560,22 +541,22 @@ where
     // Read the extracted package info
     let sinfo: String = match tfs::read_to_string(&info_path).await {
         Ok(sinfo) => sinfo,
-        Err(err) => {
-            fail!(Error::PackageInfoReadError { path: info_path, err });
+        Err(source) => {
+            fail!(Error::PackageInfoReadError { path: info_path, source });
         },
     };
     let info: PackageInfo = match serde_yaml::from_str(&sinfo) {
         Ok(info) => info,
-        Err(err) => {
-            fail!(Error::PackageInfoParseError { path: info_path, err });
+        Err(source) => {
+            fail!(Error::PackageInfoParseError { path: info_path, source });
         },
     };
 
     // Copy the image tar to the proper location
     let result_path: PathBuf = central.paths.packages.join(format!("{}-{}.tar", info.name, info.version));
     debug!("Moving image '{}' to '{}'...", image_path.display(), result_path.display());
-    if let Err(err) = tfs::rename(&image_path, &result_path).await {
-        fail!(image_path, Error::FileMoveError { from: image_path, to: result_path, err });
+    if let Err(source) = tfs::rename(&image_path, &result_path).await {
+        fail!(image_path, Error::FileMoveError { from: image_path, to: result_path, source });
     }
 
     // Call the insert function to store the dataset in the registry

--- a/brane-ast/Cargo.toml
+++ b/brane-ast/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2.18"
 serde = { version = "1.0.204", features = ["rc"] }
 serde_json_any_key = "2.0.0"
 strum = { version = "0.27.0", features = ["derive"] }
+thiserror = "2.0.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 
 brane-dsl = { path = "../brane-dsl" }

--- a/brane-ast/src/compile.rs
+++ b/brane-ast/src/compile.rs
@@ -302,18 +302,18 @@ pub fn compile_snippet_to<R: std::io::Read>(
     trace!("Reading input");
     let mut reader: R = reader;
     let mut source: String = String::new();
-    if let Err(err) = reader.read_to_string(&mut source) {
-        return CompileResult::Err(vec![Error::ReaderReadError { err }]);
+    if let Err(source) = reader.read_to_string(&mut source) {
+        return CompileResult::Err(vec![Error::ReaderReadError { source }]);
     }
     // ...and compile it to a program
     trace!("Parsing as {}", options.lang);
     let mut program: Program = match brane_dsl::parse(source, package_index, options) {
         Ok(program) => program,
         Err(ParseError::Eof { lang, err }) => {
-            return CompileResult::Eof(Error::ParseError { err: ParseError::Eof { lang, err } });
+            return CompileResult::Eof(Error::ParseError { source: ParseError::Eof { lang, err } });
         },
-        Err(err) => {
-            return CompileResult::Err(vec![Error::ParseError { err }]);
+        Err(source) => {
+            return CompileResult::Err(vec![Error::ParseError { source }]);
         },
     };
 

--- a/brane-ast/src/data_type.rs
+++ b/brane-ast/src/data_type.rs
@@ -13,7 +13,6 @@
 //!   transferral along the wire).
 //
 
-use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FResult};
 
 use serde::{Deserialize, Serialize};
@@ -23,23 +22,12 @@ use crate::spec::BuiltinClasses;
 
 /***** AUXILLARY ERRORS *****/
 /// Defines errors that occur when parsing DataTypes.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DataTypeError {
     /// The given string was not recognized.
+    #[error("Unknown data type '{raw}'")]
     UnknownDataType { raw: String },
 }
-
-impl Display for DataTypeError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DataTypeError::*;
-        match self {
-            UnknownDataType { raw } => write!(f, "Unknown data type '{raw}'"),
-        }
-    }
-}
-
-impl Error for DataTypeError {}
 
 
 

--- a/brane-ast/src/func_id.rs
+++ b/brane-ast/src/func_id.rs
@@ -13,7 +13,6 @@
 //!   platform-dependent [`usize::MAX`] to indicate the main function.
 //
 
-use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FResult};
 use std::str::FromStr;
 
@@ -25,31 +24,12 @@ use serde::ser::{Serialize, Serializer};
 
 /***** ERRORS *****/
 /// Defines errors when parsing `FunctionId` from a string.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum FunctionIdParseError {
     /// Failed to parse the given string as a numerical ID.
-    InvalidId { raw: String, err: std::num::ParseIntError },
+    #[error("Failed to parse '{raw}' as a valid function ID (i.e., unsigned integer)")]
+    InvalidId { raw: String, source: std::num::ParseIntError },
 }
-impl Display for FunctionIdParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use FunctionIdParseError::*;
-        match self {
-            InvalidId { raw, .. } => write!(f, "Failed to parse '{raw}' as a valid function ID (i.e., unsigned integer)"),
-        }
-    }
-}
-impl Error for FunctionIdParseError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use FunctionIdParseError::*;
-        match self {
-            InvalidId { err, .. } => Some(err),
-        }
-    }
-}
-
-
-
-
 
 /***** LIBRARY *****/
 /// Enum that can be used for function identifiers, to specially handle `main`.
@@ -128,7 +108,7 @@ impl FromStr for FunctionId {
         // Then parse it as an integer number
         match usize::from_str(s) {
             Ok(id) => Ok(Self::Func(id)),
-            Err(err) => Err(FunctionIdParseError::InvalidId { raw: s.into(), err }),
+            Err(source) => Err(FunctionIdParseError::InvalidId { raw: s.into(), source }),
         }
     }
 }

--- a/brane-ast/src/traversals/print/ast.rs
+++ b/brane-ast/src/traversals/print/ast.rs
@@ -528,96 +528,66 @@ fn pass_edge_instr(writer: &mut impl Write, instr: &EdgeInstr, table: &SymTable)
 pub fn do_traversal(root: &Workflow, mut writer: impl Write) -> Result<(), Vec<Error>> {
     let Workflow { id, table, metadata, user, graph, funcs } = root;
 
-    if let Err(err) = writeln!(&mut writer, "Workflow '{id}' {{") {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    writeln!(&mut writer, "Workflow '{id}' {{").map_err(|source| vec![Error::WriteError { source }])?;
 
     // Print parsed metadata
     if user.is_some() || !metadata.is_empty() {
         // Print the user
         if let Some(user) = &**user {
             // Write it
-            if let Err(err) = writeln!(&mut writer, "{}User: '{}'", indent!(INDENT_SIZE), user) {
-                return Err(vec![Error::WriteError { err }]);
-            };
+            writeln!(&mut writer, "{}User: '{}'", indent!(INDENT_SIZE), user).map_err(|source| vec![Error::WriteError { source }])?;
 
             // Write a newline separating the tags
             if !metadata.is_empty() {
-                if let Err(err) = writeln!(&mut writer) {
-                    return Err(vec![Error::WriteError { err }]);
-                };
+                writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
             }
         }
 
         // Print the metadata
         for md in metadata.iter() {
-            if let Err(err) = writeln!(
+            writeln!(
                 &mut writer,
                 "{}#{}.{}{}",
                 indent!(INDENT_SIZE),
                 if md.owner.contains(' ') { format!("\"{}\"", md.owner) } else { md.owner.clone() },
                 if md.tag.contains(' ') { format!("\"{}\"", md.tag) } else { md.tag.clone() },
                 if let Some((assigner, signature)) = &md.signature { format!(" <{assigner}.{signature}>") } else { String::new() }
-            ) {
-                return Err(vec![Error::WriteError { err }]);
-            };
+            )
+            .map_err(|source| vec![Error::WriteError { source }])?;
         }
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
     }
 
     // First up: print the workflow table
-    if let Err(err) = pass_table(&mut writer, table, INDENT_SIZE) {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    pass_table(&mut writer, table, INDENT_SIZE).map_err(|source| vec![Error::WriteError { source }])?;
+
     if !root.table.vars.is_empty()
         || !root.table.funcs.is_empty()
         || !root.table.tasks.is_empty()
         || !root.table.classes.is_empty()
         || !root.table.results.is_empty()
     {
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
     }
 
     // Print the main function body (and thus all function bodies)
-    if let Err(err) = writeln!(&mut writer, "{}<Main>", indent!(INDENT_SIZE)) {
-        return Err(vec![Error::WriteError { err }]);
-    };
-    if let Err(err) = pass_edges(&mut writer, 0, graph, table, INDENT_SIZE, &mut HashSet::new()) {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    writeln!(&mut writer, "{}<Main>", indent!(INDENT_SIZE)).map_err(|source| vec![Error::WriteError { source }])?;
+    pass_edges(&mut writer, 0, graph, table, INDENT_SIZE, &mut HashSet::new()).map_err(|source| vec![Error::WriteError { source }])?;
 
     // Print the functions
     for (i, f) in funcs.iter() {
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer, "{}<Function {} ({})>", indent!(INDENT_SIZE), *i, table.funcs[*i].name) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = pass_edges(&mut writer, 0, f, table, INDENT_SIZE, &mut HashSet::new()) {
-            return Err(vec![Error::WriteError { err }]);
-        };
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer, "{}<Function {} ({})>", indent!(INDENT_SIZE), *i, table.funcs[*i].name)
+            .map_err(|source| vec![Error::WriteError { source }])?;
+        pass_edges(&mut writer, 0, f, table, INDENT_SIZE, &mut HashSet::new()).map_err(|source| vec![Error::WriteError { source }])?;
     }
 
     // Done
-    if let Err(err) = writeln!(&mut writer, "}}") {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    writeln!(&mut writer, "}}").map_err(|source| vec![Error::WriteError { source }])?;
+
     Ok(())
 }

--- a/brane-ast/src/traversals/print/ast_unresolved.rs
+++ b/brane-ast/src/traversals/print/ast_unresolved.rs
@@ -480,73 +480,44 @@ pub fn pass_edge_instr(writer: &mut impl Write, instr: &EdgeInstr, table: &Table
 pub fn do_traversal(state: &CompileState, root: UnresolvedWorkflow, mut writer: impl Write) -> Result<UnresolvedWorkflow, Vec<Error>> {
     let UnresolvedWorkflow { main_edges, f_edges, metadata } = &root;
 
-    if let Err(err) = writeln!(&mut writer, "UnresolvedWorkflow {{") {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    writeln!(&mut writer, "UnresolvedWorkflow {{").map_err(|source| vec![Error::WriteError { source }])?;
 
     // Print parsed metadata
     if !metadata.is_empty() {
         for md in metadata.iter() {
-            if let Err(err) = writeln!(
+            writeln!(
                 &mut writer,
                 "{}#{}.{}{}",
                 indent!(INDENT_SIZE),
                 if md.owner.contains(' ') { format!("\"{}\"", md.owner) } else { md.owner.clone() },
                 if md.tag.contains(' ') { format!("\"{}\"", md.tag) } else { md.tag.clone() },
                 if let Some((assigner, signature)) = &md.signature { format!(" <{assigner}.{signature}>") } else { String::new() }
-            ) {
-                return Err(vec![Error::WriteError { err }]);
-            };
+            )
+            .map_err(|source| vec![Error::WriteError { source }])?;
         }
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
     }
 
     // First up: print the workflow's table
-    if let Err(err) = pass_table(&mut writer, &state.table, INDENT_SIZE) {
-        return Err(vec![Error::WriteError { err }]);
-    };
-    if let Err(err) = writeln!(&mut writer) {
-        return Err(vec![Error::WriteError { err }]);
-    };
-    if let Err(err) = writeln!(&mut writer) {
-        return Err(vec![Error::WriteError { err }]);
-    };
-    if let Err(err) = writeln!(&mut writer) {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    pass_table(&mut writer, &state.table, INDENT_SIZE).map_err(|source| vec![Error::WriteError { source }])?;
+    writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+    writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+    writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
 
     // Print the main function body
-    if let Err(err) = pass_edges(&mut writer, main_edges, &state.table, INDENT_SIZE, HashSet::new()) {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    pass_edges(&mut writer, main_edges, &state.table, INDENT_SIZE, HashSet::new()).map_err(|source| vec![Error::WriteError { source }])?;
 
     // Print the function edges
     if !f_edges.is_empty() {
-        if let Err(err) = pass_f_edges(&mut writer, f_edges, &state.table, INDENT_SIZE) {
-            return Err(vec![Error::WriteError { err }]);
-        }
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
-        if let Err(err) = writeln!(&mut writer) {
-            return Err(vec![Error::WriteError { err }]);
-        };
+        pass_f_edges(&mut writer, f_edges, &state.table, INDENT_SIZE).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+        writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
     }
 
     // Done
-    if let Err(err) = writeln!(&mut writer, "}}") {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    writeln!(&mut writer, "}}").map_err(|source| vec![Error::WriteError { source }])?;
     Ok(root)
 }

--- a/brane-ast/src/traversals/print/dsl.rs
+++ b/brane-ast/src/traversals/print/dsl.rs
@@ -761,7 +761,7 @@ pub fn pass_literal(writer: &mut impl Write, literal: &Literal) -> std::io::Resu
 /// This pass doesn't really error, but is here for convention purposes.
 pub fn do_traversal(root: Program, mut writer: impl Write) -> Result<Program, Vec<Error>> {
     // Write the metadata
-    if let Err(err) = writeln!(
+    writeln!(
         &mut writer,
         "{}\n",
         root.metadata
@@ -773,23 +773,18 @@ pub fn do_traversal(root: Program, mut writer: impl Write) -> Result<Program, Ve
             ))
             .collect::<Vec<String>>()
             .join(" ")
-    ) {
-        return Err(vec![Error::WriteError { err }]);
-    }
+    )
+    .map_err(|source| vec![Error::WriteError { source }])?;
+
     // Write the attributes
     for a in &root.block.attrs {
-        if let Err(err) = pass_attr(&mut writer, a, true, 0) {
-            return Err(vec![Error::WriteError { err }]);
-        }
+        pass_attr(&mut writer, a, true, 0).map_err(|source| vec![Error::WriteError { source }])?;
     }
-    if let Err(err) = writeln!(&mut writer) {
-        return Err(vec![Error::WriteError { err }]);
-    }
+    writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
+
     // Iterate over all statements and run the appropriate match
     for s in &root.block.stmts {
-        if let Err(err) = pass_stmt(&mut writer, s, 0) {
-            return Err(vec![Error::WriteError { err }]);
-        }
+        pass_stmt(&mut writer, s, 0).map_err(|source| vec![Error::WriteError { source }])?;
     }
 
     // Done

--- a/brane-ast/src/traversals/print/symbol_tables.rs
+++ b/brane-ast/src/traversals/print/symbol_tables.rs
@@ -227,15 +227,9 @@ pub fn do_traversal(root: Program, writer: impl Write) -> Result<Program, Vec<Er
     let mut writer = writer;
 
     // Iterate over all statements and run the appropriate match
-    if let Err(err) = write!(&mut writer, "__root ") {
-        return Err(vec![Error::WriteError { err }]);
-    };
-    if let Err(err) = pass_block(&mut writer, &root.block, 0) {
-        return Err(vec![Error::WriteError { err }]);
-    };
-    if let Err(err) = writeln!(&mut writer) {
-        return Err(vec![Error::WriteError { err }]);
-    };
+    write!(&mut writer, "__root ").map_err(|source| vec![Error::WriteError { source }])?;
+    pass_block(&mut writer, &root.block, 0).map_err(|source| vec![Error::WriteError { source }])?;
+    writeln!(&mut writer).map_err(|source| vec![Error::WriteError { source }])?;
 
     // Done
     Ok(root)

--- a/brane-ast/src/traversals/resolve.rs
+++ b/brane-ast/src/traversals/resolve.rs
@@ -59,8 +59,13 @@ fn define_func(entry: &mut FunctionEntry, params: &mut [Identifier], symbol_tabl
                 Ok(e) => {
                     entry.params.push(e);
                 },
-                Err(err) => {
-                    errors.push(Error::ParameterDefineError { func_name: entry.name.clone(), name: p.value.clone(), err, range: p.range().clone() });
+                Err(source) => {
+                    errors.push(Error::ParameterDefineError {
+                        func_name: entry.name.clone(),
+                        name: p.value.clone(),
+                        source,
+                        range: p.range().clone(),
+                    });
                     continue;
                 },
             };
@@ -156,8 +161,8 @@ fn pass_stmt(
             // First: parse the version
             let semver: Version = match version.as_version() {
                 Ok(version) => version,
-                Err(err) => {
-                    errors.push(Error::VersionParseError { err, range: version.range().clone() });
+                Err(source) => {
+                    errors.push(Error::VersionParseError { source, range: version.range().clone() });
                     return;
                 },
             };
@@ -193,8 +198,8 @@ fn pass_stmt(
                     Ok(entry) => {
                         funcs.push(entry);
                     },
-                    Err(err) => {
-                        errors.push(Error::FunctionImportError { package_name: info.name.clone(), name: name.into(), err, range: range.clone() });
+                    Err(source) => {
+                        errors.push(Error::FunctionImportError { package_name: info.name.clone(), name: name.into(), source, range: range.clone() });
                         return;
                     },
                 }
@@ -212,8 +217,8 @@ fn pass_stmt(
                         for p in properties.iter() {
                             match cst.add_var(VarEntry::from_prop(p.0, p.1, name, range.clone())) {
                                 Ok(_) => {},
-                                Err(err) => {
-                                    errors.push(Error::VariableDefineError { name: p.0.clone(), err, range: range.clone() });
+                                Err(source) => {
+                                    errors.push(Error::VariableDefineError { name: p.0.clone(), source, range: range.clone() });
                                     return;
                                 },
                             }
@@ -233,8 +238,8 @@ fn pass_stmt(
                     Ok(entry) => {
                         classes.push(entry);
                     },
-                    Err(err) => {
-                        errors.push(Error::ClassImportError { package_name: info.name.clone(), name: name.into(), err, range: range.clone() });
+                    Err(source) => {
+                        errors.push(Error::ClassImportError { package_name: info.name.clone(), name: name.into(), source, range: range.clone() });
                         return;
                     },
                 }
@@ -256,8 +261,8 @@ fn pass_stmt(
                     Ok(entry) => {
                         *st_entry = Some(entry);
                     },
-                    Err(err) => {
-                        errors.push(Error::FunctionDefineError { name: ident.value.clone(), err, range: ident.range().clone() });
+                    Err(source) => {
+                        errors.push(Error::FunctionDefineError { name: ident.value.clone(), source, range: ident.range().clone() });
                         return;
                     },
                 }
@@ -291,8 +296,8 @@ fn pass_stmt(
                         Ok(entry) => {
                             p.st_entry = Some(entry);
                         },
-                        Err(err) => {
-                            errors.push(Error::VariableDefineError { name: ident.value.clone(), err, range: range.clone() });
+                        Err(source) => {
+                            errors.push(Error::VariableDefineError { name: ident.value.clone(), source, range: range.clone() });
                             return;
                         },
                     }
@@ -340,8 +345,8 @@ fn pass_stmt(
                             Ok(entry) => {
                                 *m_st_entry = Some(entry);
                             },
-                            Err(err) => {
-                                errors.push(Error::FunctionDefineError { name: m_ident.value.clone(), err, range: m_range.clone() });
+                            Err(source) => {
+                                errors.push(Error::FunctionDefineError { name: m_ident.value.clone(), source, range: m_range.clone() });
                                 return;
                             },
                         }
@@ -358,8 +363,8 @@ fn pass_stmt(
                     Ok(entry) => {
                         *st_entry = Some(entry);
                     },
-                    Err(err) => {
-                        errors.push(Error::ClassDefineError { name: ident.value.clone(), err, range: range.clone() });
+                    Err(source) => {
+                        errors.push(Error::ClassDefineError { name: ident.value.clone(), source, range: range.clone() });
                         return;
                     },
                 }
@@ -439,8 +444,8 @@ fn pass_stmt(
                     Ok(entry) => {
                         *st_entry = Some(entry);
                     },
-                    Err(err) => {
-                        errors.push(Error::VariableDefineError { name: result.value.clone(), err, range: result.range().clone() });
+                    Err(source) => {
+                        errors.push(Error::VariableDefineError { name: result.value.clone(), source, range: result.range().clone() });
                     },
                 }
             }
@@ -456,8 +461,8 @@ fn pass_stmt(
                 Ok(entry) => {
                     *st_entry = Some(entry);
                 },
-                Err(err) => {
-                    errors.push(Error::VariableDefineError { name: name.value.clone(), err, range: name.range().clone() });
+                Err(source) => {
+                    errors.push(Error::VariableDefineError { name: name.value.clone(), source, range: name.range().clone() });
                 },
             }
         },

--- a/brane-cc/Cargo.toml
+++ b/brane-cc/Cargo.toml
@@ -18,6 +18,7 @@ enum-debug.workspace = true
 humanlog.workspace = true
 human-panic = "2.0.0"
 log = "0.4.22"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["rt","macros"] }
 url = "2.5.0"
 

--- a/brane-cc/src/errors.rs
+++ b/brane-cc/src/errors.rs
@@ -12,69 +12,49 @@
 //!   Defines errors for the `brane-cc` crate.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::path::PathBuf;
 
 
 /***** LIBRARY *****/
 /// Collects errors that relate to offline compilation.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CompileError {
     /// Failed to open the given input file.
-    InputOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open input file '{}'", path.display())]
+    InputOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read from the input.
-    InputReadError { name: String, err: std::io::Error },
+    #[error("Failed to read from input '{name}'")]
+    InputReadError { name: String, source: std::io::Error },
     /// Failed to fetch the remote package index.
-    RemotePackageIndexError { endpoint: String, err: brane_tsk::api::Error },
+    #[error("Failed to fetch remote package index from '{endpoint}'")]
+    RemotePackageIndexError { endpoint: String, source: brane_tsk::api::Error },
     /// Failed to fetch the remote data index.
-    RemoteDataIndexError { endpoint: String, err: brane_tsk::api::Error },
+    #[error("Failed to fetch remote data index from '{endpoint}'")]
+    RemoteDataIndexError { endpoint: String, source: brane_tsk::api::Error },
     /// Failed to fetch the local package index.
-    LocalPackageIndexError { err: brane_tsk::local::Error },
+    #[error("Failed to fetch local package index")]
+    LocalPackageIndexError { source: brane_tsk::local::Error },
     /// Failed to fetch the local data index.
-    LocalDataIndexError { err: brane_tsk::local::Error },
+    #[error("Failed to fetch local data index")]
+    LocalDataIndexError { source: brane_tsk::local::Error },
     /// Failed to serialize workflow.
-    WorkflowSerializeError { err: serde_json::Error },
+    #[error("Failed to serialize the compiled workflow")]
+    WorkflowSerializeError { source: serde_json::Error },
     /// Failed to create the given output file.
-    OutputCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create output file '{}'", path.display())]
+    OutputCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the given output file.
-    OutputWriteError { name: String, err: std::io::Error },
+    #[error("Failed to write to output '{name}'")]
+    OutputWriteError { name: String, source: std::io::Error },
 
     /// Compilation itself failed.
-    CompileError { errs: Vec<brane_ast::Error> },
+    #[error("Failed to compile given workflow (see output above)")]
+    CompileError { sources: Vec<brane_ast::Error> },
 }
-
-impl Display for CompileError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use self::CompileError::*;
-        match self {
-            InputOpenError { path, err } => write!(f, "Failed to open input file '{}': {}", path.display(), err),
-            InputReadError { name, err } => write!(f, "Failed to read from input '{name}': {err}"),
-            RemotePackageIndexError { endpoint, err } => write!(f, "Failed to fetch remote package index from '{endpoint}': {err}"),
-            RemoteDataIndexError { endpoint, err } => write!(f, "Failed to fetch remote data index from '{endpoint}': {err}"),
-            LocalPackageIndexError { err } => write!(f, "Failed to fetch local package index: {err}"),
-            LocalDataIndexError { err } => write!(f, "Failed to fetch local data index: {err}"),
-            WorkflowSerializeError { err } => write!(f, "Failed to serialize the compiled workflow: {err}"),
-            OutputCreateError { path, err } => write!(f, "Failed to create output file '{}': {}", path.display(), err),
-            OutputWriteError { name, err } => write!(f, "Failed to write to output '{name}': {err}"),
-
-            CompileError { .. } => write!(f, "Failed to compile given workflow (see output above)"),
-        }
-    }
-}
-
-impl Error for CompileError {}
 
 
 
 /// Defines errors that occur when attempting to parse an IndexLocationParseError.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("The impossible has happened; an IndexLocationParseError was raised, even though none exist")]
 pub struct IndexLocationParseError;
-
-impl Display for IndexLocationParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        write!(f, "The impossible has happened; an IndexLocationParseError was raised, even though none exist")
-    }
-}
-
-impl Error for IndexLocationParseError {}

--- a/brane-cfg/Cargo.toml
+++ b/brane-cfg/Cargo.toml
@@ -15,6 +15,7 @@ rustls = "0.21.6"
 rustls-pemfile = "1.0.1"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = [] }
 x509-parser = "0.17.0"
 

--- a/brane-cfg/src/errors.rs
+++ b/brane-cfg/src/errors.rs
@@ -12,126 +12,87 @@
 //!   Defines errors that occur in the `brane-cfg` crate.
 //
 
-use std::error::Error;
-use std::fmt::{Debug, Display, Formatter, Result as FResult};
+use std::fmt::Debug;
 use std::path::PathBuf;
 
 
 /***** LIBRARY *****/
 /// Errors that relate to certificate loading and such.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CertsError {
     /// A given certificate file could not be parsed.
-    ClientCertParseError { err: x509_parser::nom::Err<x509_parser::error::X509Error> },
+    #[error("Failed to parse given client certificate file")]
+    ClientCertParseError { source: x509_parser::nom::Err<x509_parser::error::X509Error> },
     /// A given certificate did not have the `CN`-field specified.
+    #[error("Certificate subject field '{subject}' does not specify a CN")]
     ClientCertNoCN { subject: String },
 
     /// Failed to open a given file.
-    FileOpenError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to open {} file '{}'", what, path.display())]
+    FileOpenError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to read a given file.
-    FileReadError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to read {} file '{}'", what, path.display())]
+    FileReadError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Encountered unknown item in the given file.
+    #[error("Encountered non-certificate, non-key item in {} file '{}'", what, path.display())]
     UnknownItemError { what: &'static str, path: PathBuf },
 
     /// Failed to parse the certificate file.
-    CertFileParseError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to parse certificates in '{}'", path.display())]
+    CertFileParseError { path: PathBuf, source: std::io::Error },
     /// Failed to parse the key file.
-    KeyFileParseError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to parse keys in '{}'", path.display())]
+    KeyFileParseError { path: PathBuf, source: std::io::Error },
 
     /// The given certificate file was empty.
+    #[error("No certificates found in file '{}'", path.display())]
     EmptyCertFile { path: PathBuf },
     /// The given keyfile was empty.
+    #[error("No keys found in file '{}'", path.display())]
     EmptyKeyFile { path: PathBuf },
 }
-impl Display for CertsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use CertsError::*;
-        match self {
-            ClientCertParseError { err } => write!(f, "Failed to parse given client certificate file: {err}"),
-            ClientCertNoCN { subject } => write!(f, "Certificate subject field '{subject}' does not specify a CN"),
-
-            FileOpenError { what, path, err } => write!(f, "Failed to open {} file '{}': {}", what, path.display(), err),
-            FileReadError { what, path, err } => write!(f, "Failed to read {} file '{}': {}", what, path.display(), err),
-            UnknownItemError { what, path } => write!(f, "Encountered non-certificate, non-key item in {} file '{}'", what, path.display()),
-
-            CertFileParseError { path, err } => write!(f, "Failed to parse certificates in '{}': {}", path.display(), err),
-            KeyFileParseError { path, err } => write!(f, "Failed to parse keys in '{}': {}", path.display(), err),
-
-            EmptyCertFile { path } => write!(f, "No certificates found in file '{}'", path.display()),
-            EmptyKeyFile { path } => write!(f, "No keys found in file '{}'", path.display()),
-        }
-    }
-}
-impl Error for CertsError {}
-
 
 
 /// Errors that relate to a NodeConfig.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum NodeConfigError {
     /// Failed to open the given config path.
-    FileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open the node config file '{}'", path.display())]
+    FileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read from the given config path.
-    FileReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read the ndoe config file '{}'", path.display())]
+    FileReadError { path: PathBuf, source: std::io::Error },
     /// Failed to parse the given file.
-    FileParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse node config file '{}' as YAML", path.display())]
+    FileParseError { path: PathBuf, source: serde_yaml::Error },
 
     /// Failed to open the given config path.
-    FileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create the node config file '{}'", path.display())]
+    FileCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the given config path.
-    FileWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to the ndoe config file '{}'", path.display())]
+    FileWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to serialze the NodeConfig.
-    ConfigSerializeError { err: serde_yaml::Error },
+    #[error("Failed to serialize node config to YAML")]
+    ConfigSerializeError { source: serde_yaml::Error },
 
     /// Failed to write to the given writer.
-    WriterWriteError { err: std::io::Error },
+    #[error("Failed to write to given writer")]
+    WriterWriteError { source: std::io::Error },
 }
-impl Display for NodeConfigError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use NodeConfigError::*;
-        match self {
-            FileOpenError { path, err } => write!(f, "Failed to open the node config file '{}': {}", path.display(), err),
-            FileReadError { path, err } => write!(f, "Failed to read the ndoe config file '{}': {}", path.display(), err),
-            FileParseError { path, err } => write!(f, "Failed to parse node config file '{}' as YAML: {}", path.display(), err),
-
-            FileCreateError { path, err } => write!(f, "Failed to create the node config file '{}': {}", path.display(), err),
-            FileWriteError { path, err } => write!(f, "Failed to write to the ndoe config file '{}': {}", path.display(), err),
-            ConfigSerializeError { err } => write!(f, "Failed to serialize node config to YAML: {err}"),
-
-            WriterWriteError { err } => write!(f, "Failed to write to given writer: {err}"),
-        }
-    }
-}
-impl Error for NodeConfigError {}
 
 /// Defines errors that may occur when parsing proxy protocol strings.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ProxyProtocolParseError {
     /// The protocol (version) is unknown to us.
+    #[error("Unknown proxy protocol '{raw}'")]
     UnknownProtocol { raw: String },
 }
-impl Display for ProxyProtocolParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ProxyProtocolParseError::*;
-        match self {
-            UnknownProtocol { raw } => write!(f, "Unknown proxy protocol '{raw}'"),
-        }
-    }
-}
-impl Error for ProxyProtocolParseError {}
 
 /// Defines errors that may occur when parsing node kind strings.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum NodeKindParseError {
     /// The given NodeKind was unknown to us.
+    #[error("Unknown node kind '{raw}'")]
     UnknownNodeKind { raw: String },
 }
-impl Display for NodeKindParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use NodeKindParseError::*;
-        match self {
-            UnknownNodeKind { raw } => write!(f, "Unknown node kind '{raw}'"),
-        }
-    }
-}
-impl Error for NodeKindParseError {}

--- a/brane-cli-c/src/lib.rs
+++ b/brane-cli-c/src/lib.rs
@@ -1415,7 +1415,7 @@ pub unsafe extern "C" fn vm_run(
 // TODO: Resolve this problem
 //
 /// /// <div class="warning">
-/// This function is currently broken because of ecosystem changes. See: https://github.com/braneframework/brane/issues/195
+/// This function is currently broken because of ecosystem changes. See: https://github.com/epi-project/brane/issues/195
 /// </div>
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -55,6 +55,7 @@ serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tar = "0.4.21"
 tempfile = "3.10.1"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-stream = "0.1.6"
 tokio-util = { version = "0.7.1", features = ["codec"] }

--- a/brane-cli/src/data.rs
+++ b/brane-cli/src/data.rs
@@ -80,8 +80,6 @@ pub async fn download_data(
     let data_dir: &Path = data_dir.as_ref();
     let name: &str = name.as_ref();
 
-
-
     /* Step 1: Get target registry address */
     // Choose a random location to attempt to download the asset from.
     if access.is_empty() {

--- a/brane-cli/src/data.rs
+++ b/brane-cli/src/data.rs
@@ -90,14 +90,15 @@ pub async fn download_data(
 
     // Send a GET-request to resolve that location to a delegate
     let registry_addr = format!("{api_endpoint}/infra/registries/{location}");
-    let res = reqwest::get(&registry_addr).await.map_err(|err| DataError::RequestError { what: "registry", address: registry_addr.clone(), err })?;
+    let res =
+        reqwest::get(&registry_addr).await.map_err(|source| DataError::RequestError { what: "registry", address: registry_addr.clone(), source })?;
 
     // Attempt to get its body if it was a success
     if !res.status().is_success() {
         return Err(DataError::RequestFailure { address: registry_addr, code: res.status(), message: res.text().await.ok() });
     }
 
-    let registry_addr: String = res.text().await.map_err(|err| DataError::ResponseTextError { address: registry_addr, err })?;
+    let registry_addr: String = res.text().await.map_err(|source| DataError::ResponseTextError { address: registry_addr, source })?;
 
     debug!("Remote registry: '{}'", registry_addr);
 
@@ -110,15 +111,17 @@ pub async fn download_data(
         let cafile = cert_dir.join("ca.pem");
 
         // Load the keypair for this location as an Identity file (for which we just smash 'em together and hope that works)
-        let ident_raw = tfs::read(&idfile).await.map_err(|err| DataError::FileReadError { what: "client identity", path: idfile.clone(), err })?;
+        let ident_raw =
+            tfs::read(&idfile).await.map_err(|source| DataError::FileReadError { what: "client identity", path: idfile.clone(), source })?;
 
-        let ident = Identity::from_pem(&ident_raw).map_err(|err| DataError::IdentityFileError { path: idfile.clone(), err })?;
-
-        // Load the root store for this location (also as a list of certificates)
-        let raw_root = tfs::read(&cafile).await.map_err(|err| DataError::FileReadError { what: "server cert root", path: cafile.clone(), err })?;
+        let ident = Identity::from_pem(&ident_raw).map_err(|source| DataError::IdentityFileError { path: idfile.clone(), source })?;
 
         // Load the root store for this location (also as a list of certificates)
-        let root = Certificate::from_pem(&raw_root).map_err(|err| DataError::CertificateError { path: cafile, err })?;
+        let raw_root =
+            tfs::read(&cafile).await.map_err(|source| DataError::FileReadError { what: "server cert root", path: cafile.clone(), source })?;
+
+        // Load the root store for this location (also as a list of certificates)
+        let root = Certificate::from_pem(&raw_root).map_err(|source| DataError::CertificateError { path: cafile, source })?;
 
         // Return them, with the cert and key as identity
         (ident, root)
@@ -128,7 +131,7 @@ pub async fn download_data(
     debug!("Preparing filesystem...");
 
     // Make sure the temporary tarfile directory exists
-    let tar_dir = TempDir::new().map_err(|err| DataError::TempDirError { err })?;
+    let tar_dir = TempDir::new().map_err(|source| DataError::TempDirError { source })?;
     let tar_path = tar_dir.path().join(format!("data_{name}.tar.gz"));
 
     // Make sure the old data path doesn't exist anymore
@@ -137,7 +140,7 @@ pub async fn download_data(
         if !data_path.is_dir() {
             return Err(DataError::DirNotADirError { what: "target data", path: data_path });
         }
-        tfs::remove_dir_all(&data_path).await.map_err(|err| DataError::DirRemoveError { what: "target data", path: data_path.clone(), err })?;
+        tfs::remove_dir_all(&data_path).await.map_err(|source| DataError::DirRemoveError { what: "target data", path: data_path.clone(), source })?;
     }
 
     /* Step 4: Build the client. */
@@ -147,10 +150,10 @@ pub async fn download_data(
         Client::builder().use_rustls_tls().add_root_certificate(ca_cert).identity(identity).tls_sni(!is_ip_addr(&download_addr));
 
     if let Some(proxy_addr) = proxy_addr {
-        client = client.proxy(Proxy::all(proxy_addr).map_err(|err| DataError::ProxyCreateError { address: proxy_addr.into(), err })?);
+        client = client.proxy(Proxy::all(proxy_addr).map_err(|source| DataError::ProxyCreateError { address: proxy_addr.into(), source })?);
     }
 
-    let client = client.build().map_err(|err| DataError::ClientCreateError { err })?;
+    let client = client.build().map_err(|source| DataError::ClientCreateError { source })?;
 
     // Send a reqwest
     let res = client
@@ -158,12 +161,12 @@ pub async fn download_data(
         .json(&DownloadAssetRequest {
             use_case,
             workflow: serde_json::to_value(workflow)
-                .map_err(|err| DataError::WorkflowSerializeError { context: String::from("creating download asset request"), err })?,
+                .map_err(|source| DataError::WorkflowSerializeError { context: String::from("creating download asset request"), source })?,
             task: None,
         })
         .send()
         .await
-        .map_err(|err| DataError::RequestError { what: "download", address: download_addr.clone(), err })?;
+        .map_err(|source| DataError::RequestError { what: "download", address: download_addr.clone(), source })?;
 
     if !res.status().is_success() {
         return Err(DataError::RequestFailure { address: download_addr, code: res.status(), message: res.text().await.ok() });
@@ -172,21 +175,21 @@ pub async fn download_data(
     /* Step 5: Download the raw file in parts */
     debug!("Downloading file to '{}'...", tar_path.display());
     {
-        let mut handle = tfs::File::create(&tar_path).await.map_err(|err| DataError::TarCreateError { path: tar_path.clone(), err })?;
+        let mut handle = tfs::File::create(&tar_path).await.map_err(|source| DataError::TarCreateError { path: tar_path.clone(), source })?;
 
         let mut stream = res.bytes_stream();
         while let Some(chunk) = stream.next().await {
             // Unwrap the chunk
-            let mut chunk = chunk.map_err(|err| DataError::DownloadStreamError { address: download_addr.clone(), err })?;
+            let mut chunk = chunk.map_err(|source| DataError::DownloadStreamError { address: download_addr.clone(), source })?;
 
             // Write it to the file
-            handle.write_all_buf(&mut chunk).await.map_err(|err| DataError::TarWriteError { path: tar_path.clone(), err })?;
+            handle.write_all_buf(&mut chunk).await.map_err(|source| DataError::TarWriteError { path: tar_path.clone(), source })?;
         }
     }
 
     /* Step 6: Extract the tar. */
     debug!("Unpacking '{}' to '{}'...", tar_path.display(), data_path.display());
-    brane_shr::fs::unarchive_async(tar_path, &data_path).await.map_err(|err| DataError::TarExtractError { err })?;
+    brane_shr::fs::unarchive_async(tar_path, &data_path).await.map_err(|source| DataError::TarExtractError { source })?;
 
     /* Step 7: In the case of brane-cli, also write a DataInfo. */
     let access = AccessKind::File { path: data_path };
@@ -205,7 +208,7 @@ pub async fn download_data(
         };
 
         // Write it
-        info.to_path(&info_path).map_err(|err| DataError::DataInfoWriteError { err })?;
+        info.to_path(&info_path).map_err(|source| DataError::DataInfoWriteError { source })?;
     }
 
     /* Step 7: Done */
@@ -233,12 +236,7 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
 
     /* Step 1: Read the input */
     // Parse the input file as a AssetFile (which is a datafile but with user info attached to it).
-    let mut info: AssetInfo = match AssetInfo::from_path(file) {
-        Ok(info) => info,
-        Err(err) => {
-            return Err(DataError::AssetFileError { path: file.into(), err });
-        },
-    };
+    let mut info: AssetInfo = AssetInfo::from_path(file).map_err(|source| DataError::AssetFileError { path: file.into(), source })?;
     // Inject the current time if not already
     info.created = Utc::now();
 
@@ -249,12 +247,7 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
             if path.is_relative() {
                 // Create a new relative path
                 let apath: PathBuf = workdir.join(&path);
-                let apath: PathBuf = match apath.canonicalize() {
-                    Ok(apath) => apath,
-                    Err(err) => {
-                        return Err(DataError::FileCanonicalizeError { path: apath.clone(), err });
-                    },
-                };
+                let apath: PathBuf = apath.canonicalize().map_err(|source| DataError::FileCanonicalizeError { path: apath.clone(), source })?;
                 *path = apath;
             }
 
@@ -267,8 +260,6 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
         },
     }
 
-
-
     /* Step 2: Prepare the build directory. */
     // Before we create it though, if it happens to exist, then moan about it
     if let Ok(dir) = get_dataset_dir(&info.name) {
@@ -278,14 +269,7 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
     }
 
     // Simple use our ensure thing for this
-    let build_dir: PathBuf = match ensure_dataset_dir(&info.name, true) {
-        Ok(build_dir) => build_dir,
-        Err(err) => {
-            return Err(DataError::DatasetDirCreateError { err });
-        },
-    };
-
-
+    let build_dir: PathBuf = ensure_dataset_dir(&info.name, true).map_err(|source| DataError::DatasetDirCreateError { source })?;
 
     /* Step 3: Move any files if we don't want no links. */
     if no_links {
@@ -293,9 +277,7 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
             AccessKind::File { ref mut path } => {
                 // Perform the copy
                 let target: PathBuf = build_dir.join(path.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_else(|| "data".into()));
-                if let Err(err) = copy_dir_recursively_async(&path, &target).await {
-                    return Err(DataError::DataCopyError { err });
-                }
+                copy_dir_recursively_async(&path, &target).await.map_err(|source| DataError::DataCopyError { source })?;
 
                 // Update the path to the target
                 *path = target;
@@ -303,15 +285,10 @@ pub async fn build(file: impl AsRef<Path>, workdir: impl AsRef<Path>, _keep_file
         }
     }
 
-
-
     /* Step 4: Write the AssetInfo to a DataInfo. */
     let data_info: DataInfo = info.into();
-    if let Err(err) = data_info.to_path(build_dir.join("data.yml")) {
-        return Err(DataError::DataInfoWriteError { err });
-    }
 
-
+    data_info.to_path(build_dir.join("data.yml")).map_err(|source| DataError::DataInfoWriteError { source })?;
 
     /* Step 5: Done */
     println!("Successfully built dataset {}", style(&data_info.name).bold().cyan());
@@ -355,31 +332,17 @@ pub async fn download(
     }
 
     // Fetch the endpoint from the login file
-    let instance_info: InstanceInfo = match InstanceInfo::from_active_path() {
-        Ok(info) => info,
-        Err(err) => {
-            return Err(DataError::InstanceInfoError { err });
-        },
-    };
+    let instance_info: InstanceInfo = InstanceInfo::from_active_path().map_err(|source| DataError::InstanceInfoError { source })?;
 
     // Fetch a new, remote DataIndex to get up-to-date entries
     let data_addr: String = format!("{}/data/info", instance_info.api);
-    let index: DataIndex = match brane_tsk::api::get_data_index(&data_addr).await {
-        Ok(dindex) => dindex,
-        Err(err) => {
-            return Err(DataError::RemoteDataIndexError { address: data_addr, err });
-        },
-    };
+    let index: DataIndex =
+        brane_tsk::api::get_data_index(&data_addr).await.map_err(|source| DataError::RemoteDataIndexError { address: data_addr, source })?;
 
     // Iterate over the to-be-downloaded datasets
     for name in names {
         // Make sure we know it
-        let info: &DataInfo = match index.get(&name) {
-            Some(info) => info,
-            None => {
-                return Err(DataError::UnknownDataset { name });
-            },
-        };
+        let info: &DataInfo = index.get(&name).ok_or_else(|| DataError::UnknownDataset { name: name.clone() })?;
 
         debug!("Selecting download location for '{}'...", name);
         let loc: String = {
@@ -412,8 +375,8 @@ pub async fn download(
                     // Ask the user
                     match prompt.interact_on_opt(&Term::stderr()) {
                         Ok(res) => res.map(|i| items[i].clone()).unwrap_or_else(|| items[0].clone()),
-                        Err(err) => {
-                            return Err(DataError::DataSelectError { err });
+                        Err(source) => {
+                            return Err(DataError::DataSelectError { source });
                         },
                     }
                 }
@@ -446,32 +409,23 @@ pub async fn download(
                 let certs_dir: PathBuf = match InstanceInfo::get_active_name() {
                     Ok(name) => match InstanceInfo::get_instance_path(&name) {
                         Ok(path) => path.join("certs"),
-                        Err(err) => {
-                            return Err(DataError::InstancePathError { name, err });
+                        Err(source) => {
+                            return Err(DataError::InstancePathError { name, source });
                         },
                     },
-                    Err(err) => {
-                        return Err(DataError::ActiveInstanceReadError { err });
+                    Err(source) => {
+                        return Err(DataError::ActiveInstanceReadError { source });
                     },
                 };
 
                 // Get the path to download it to
-                let data_dir: PathBuf = match ensure_dataset_dir(&name, true) {
-                    Ok(dir) => dir,
-                    Err(err) => {
-                        return Err(DataError::DatasetDirError { name, err });
-                    },
-                };
+                let data_dir: PathBuf =
+                    ensure_dataset_dir(&name, true).map_err(|source| DataError::DatasetDirError { name: name.clone(), source })?;
 
                 // Run the download
-                match download_data(instance_info.api.to_string(), proxy_addr, certs_dir, data_dir, use_case.clone(), &name, workflow, &access)
+                download_data(instance_info.api.to_string(), proxy_addr, certs_dir, data_dir, use_case.clone(), &name, workflow, &access)
                     .await?
-                {
-                    Some(access) => access,
-                    None => {
-                        return Err(DataError::UnavailableDataset { name, locs: info.access.keys().cloned().collect() });
-                    },
-                }
+                    .ok_or_else(|| DataError::UnavailableDataset { name, locs: info.access.keys().cloned().collect() })?
             },
         };
 
@@ -501,21 +455,12 @@ pub fn list() -> Result<(), DataError> {
     table.add_row(row!["ID/NAME", "KIND", "CREATED", "LINKED?", "ACCESS"]);
 
     // Get the local datasets folder
-    let datasets_dir: PathBuf = match ensure_datasets_dir(false) {
-        Ok(datasets_dir) => datasets_dir,
-        Err(err) => {
-            return Err(DataError::DatasetsError { err });
-        },
-    };
+    let datasets_dir: PathBuf = ensure_datasets_dir(false).map_err(|source| DataError::DatasetsError { source })?;
 
     // Get the local DataIndex, which contains the local data infos
     let now: i64 = Utc::now().timestamp();
-    let index: DataIndex = match brane_tsk::local::get_data_index(datasets_dir) {
-        Ok(index) => index,
-        Err(err) => {
-            return Err(DataError::LocalDataIndexError { err });
-        },
-    };
+    let index: DataIndex = brane_tsk::local::get_data_index(datasets_dir).map_err(|source| DataError::LocalDataIndexError { source })?;
+
     for d in index {
         // Add the name/id of the dataset
         let name = pad_str(&d.name, 20, Alignment::Left, Some(".."));
@@ -568,20 +513,11 @@ pub fn list() -> Result<(), DataError> {
 /// This function may error if we failed to read any of the files or directories.
 pub fn path(datasets: Vec<impl AsRef<str>>) -> Result<(), DataError> {
     // Get the local datasets folder
-    let datasets_dir: PathBuf = match ensure_datasets_dir(false) {
-        Ok(datasets_dir) => datasets_dir,
-        Err(err) => {
-            return Err(DataError::DatasetsError { err });
-        },
-    };
+    let datasets_dir: PathBuf = ensure_datasets_dir(false).map_err(|source| DataError::DatasetsError { source })?;
 
     // Simply attempt to find all of the datasets in the local index
-    let index: DataIndex = match brane_tsk::local::get_data_index(datasets_dir) {
-        Ok(index) => index,
-        Err(err) => {
-            return Err(DataError::LocalDataIndexError { err });
-        },
-    };
+    let index: DataIndex = brane_tsk::local::get_data_index(datasets_dir).map_err(|source| DataError::LocalDataIndexError { source })?;
+
     for d in datasets {
         let d: &str = d.as_ref();
 
@@ -628,33 +564,23 @@ pub fn remove(datasets: Vec<impl AsRef<str>>, force: bool) -> Result<(), DataErr
         let d: &str = d.as_ref();
 
         // Fetch the directory of this dataset
-        let dir: PathBuf = match get_dataset_dir(d) {
-            Ok(dir) => dir,
-            Err(err) => {
-                return Err(DataError::DatasetDirError { name: d.into(), err });
-            },
-        };
+        let dir: PathBuf = get_dataset_dir(d).map_err(|source| DataError::DatasetDirError { name: d.into(), source })?;
 
         // Ask the user if they are sure
         if !force {
             println!("Are you sure you want to remove dataset {}?", style(&d).bold().cyan());
             println!("(Note that, if the dataset is linked, the dataset itself will not be removed)");
             println!();
-            let consent: bool = match Confirm::new().interact() {
-                Ok(consent) => consent,
-                Err(err) => {
-                    return Err(DataError::ConfirmationError { err });
-                },
-            };
+            let consent: bool = Confirm::new().interact().map_err(|source| DataError::ConfirmationError { source })?;
+
             if !consent {
                 return Ok(());
             }
         }
 
         // Everything checks out so just delete that folder
-        if let Err(err) = fs::remove_dir_all(&dir) {
-            return Err(DataError::RemoveError { path: dir, err });
-        }
+        fs::remove_dir_all(&dir).map_err(|source| DataError::RemoveError { path: dir, source })?;
+
         println!("Successfully removed dataset {}", style(&d).bold().cyan());
     }
 

--- a/brane-cli/src/errors.rs
+++ b/brane-cli/src/errors.rs
@@ -13,10 +13,8 @@
 //
 
 use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::path::PathBuf;
 
-use brane_shr::errors::ErrorTrace as _;
 use brane_shr::formatters::{BlockFormatter, PrettyListFormatter};
 use reqwest::StatusCode;
 use specifications::address::Address;
@@ -36,1986 +34,1103 @@ lazy_static! {
 
 /***** ERROR ENUMS *****/
 /// Collects toplevel and uncategorized errors in the brane-cli package.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CliError {
     // Toplevel errors for the subcommands
     /// Errors that occur during the build command
-    BuildError { err: BuildError },
+    #[error(transparent)]
+    BuildError { source: BuildError },
     /// Errors that occur when managing certificates.
-    CertsError { err: CertsError },
+    #[error(transparent)]
+    CertsError { source: CertsError },
     /// Errors that occur when validating workflow against policy.
-    CheckError { err: CheckError },
+    #[error(transparent)]
+    CheckError { source: CheckError },
     /// Errors that occur during any of the data(-related) command(s)
-    DataError { err: DataError },
+    #[error(transparent)]
+    DataError { source: DataError },
     /// Errors that occur during the import command
-    ImportError { err: ImportError },
+    #[error(transparent)]
+    ImportError { source: ImportError },
     /// Errors that occur during identity management.
-    InstanceError { err: InstanceError },
+    #[error(transparent)]
+    InstanceError { source: InstanceError },
     /// Errors that occur during some package command
-    PackageError { err: PackageError },
+    #[error(transparent)]
+    PackageError { source: PackageError },
     /// Errors that occur during some registry command
-    RegistryError { err: RegistryError },
+    #[error(transparent)]
+    RegistryError { source: RegistryError },
     /// Errors that occur during the repl command
-    ReplError { err: ReplError },
+    #[error(transparent)]
+    ReplError { source: ReplError },
     /// Errors that occur during the run command
-    RunError { err: RunError },
+    #[error(transparent)]
+    RunError { source: RunError },
     /// Errors that occur in the test command
-    TestError { err: TestError },
+    #[error(transparent)]
+    TestError { source: TestError },
     /// Errors that occur in the verify command
-    VerifyError { err: VerifyError },
+    #[error(transparent)]
+    VerifyError { source: VerifyError },
     /// Errors that occur in the version command
-    VersionError { err: VersionError },
+    #[error(transparent)]
+    VersionError { source: VersionError },
     /// Errors that occur when upgrading old config files.
-    UpgradeError { err: crate::upgrade::Error },
+    #[error(transparent)]
+    UpgradeError { source: crate::upgrade::Error },
     /// Errors that occur in some inter-subcommand utility
-    UtilError { err: UtilError },
+    #[error(transparent)]
+    UtilError { source: UtilError },
     /// Temporary wrapper around any anyhow error
-    OtherError { err: anyhow::Error },
+    #[error(transparent)]
+    OtherError { source: anyhow::Error },
 
     // A few miscellanous errors occuring in main.rs
     /// Could not resolve the path to the package file
-    PackageFileCanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Could not resolve package file path '{}'", path.display())]
+    PackageFileCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Could not resolve the path to the context
-    WorkdirCanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Could not resolve working directory '{}'", path.display())]
+    WorkdirCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Could not resolve a string to a package kind
-    IllegalPackageKind { kind: String, err: PackageKindError },
+    #[error("Illegal package kind '{kind}'")]
+    IllegalPackageKind { kind: String, source: PackageKindError },
     /// Could not parse a NAME:VERSION pair
-    PackagePairParseError { raw: String, err: specifications::version::ParseError },
+    #[error("Could not parse '{raw}'")]
+    PackagePairParseError { raw: String, source: specifications::version::ParseError },
 }
-impl Display for CliError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use CliError::*;
-        match self {
-            BuildError { err } => write!(f, "{err}"),
-            CertsError { err } => write!(f, "{err}"),
-            CheckError { err } => write!(f, "{err}"),
-            DataError { err } => write!(f, "{err}"),
-            ImportError { err } => write!(f, "{err}"),
-            InstanceError { err } => write!(f, "{err}"),
-            PackageError { err } => write!(f, "{err}"),
-            RegistryError { err } => write!(f, "{err}"),
-            ReplError { err } => write!(f, "{err}"),
-            RunError { err } => write!(f, "{err}"),
-            TestError { err } => write!(f, "{err}"),
-            VerifyError { err } => write!(f, "{err}"),
-            VersionError { err } => write!(f, "{err}"),
-            UpgradeError { err } => write!(f, "{err}"),
-            UtilError { err } => write!(f, "{err}"),
-            OtherError { err } => write!(f, "{err}"),
-
-            PackageFileCanonicalizeError { path, .. } => write!(f, "Could not resolve package file path '{}'", path.display()),
-            WorkdirCanonicalizeError { path, .. } => write!(f, "Could not resolve working directory '{}'", path.display()),
-            IllegalPackageKind { kind, .. } => write!(f, "Illegal package kind '{kind}'"),
-            PackagePairParseError { raw, .. } => write!(f, "Could not parse '{raw}'"),
-        }
-    }
-}
-impl Error for CliError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use CliError::*;
-        match self {
-            BuildError { err } => err.source(),
-            CertsError { err } => err.source(),
-            CheckError { err } => err.source(),
-            DataError { err } => err.source(),
-            ImportError { err } => err.source(),
-            InstanceError { err } => err.source(),
-            PackageError { err } => err.source(),
-            RegistryError { err } => err.source(),
-            ReplError { err } => err.source(),
-            RunError { err } => err.source(),
-            TestError { err } => err.source(),
-            VerifyError { err } => err.source(),
-            VersionError { err } => err.source(),
-            UpgradeError { err } => err.source(),
-            UtilError { err } => err.source(),
-            OtherError { err } => err.source(),
-
-            PackageFileCanonicalizeError { err, .. } => Some(err),
-            WorkdirCanonicalizeError { err, .. } => Some(err),
-            IllegalPackageKind { err, .. } => Some(err),
-            PackagePairParseError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors during the build subcommand
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum BuildError {
     /// Could not open the given container info file
-    ContainerInfoOpenError { file: PathBuf, err: std::io::Error },
+    #[error("Could not open the container info file '{}'", file.display())]
+    ContainerInfoOpenError { file: PathBuf, source: std::io::Error },
     /// Could not read/open the given container info file
-    ContainerInfoParseError { file: PathBuf, err: ContainerInfoError },
+    #[error("Could not parse the container info file '{}'", file.display())]
+    ContainerInfoParseError { file: PathBuf, source: ContainerInfoError },
     /// Could not create/resolve the package directory
-    PackageDirError { err: UtilError },
+    #[error("Could not create package directory")]
+    PackageDirError { source: UtilError },
 
     /// Could not read/open the given OAS document
-    OasDocumentParseError { file: PathBuf, err: anyhow::Error },
+    #[error("Could not parse the OAS Document '{}'", file.display())]
+    OasDocumentParseError { file: PathBuf, source: anyhow::Error },
     /// Could not parse the version in the given OAS document
-    VersionParseError { err: VersionParseError },
+    #[error("Could not parse OAS Document version number")]
+    VersionParseError { source: VersionParseError },
     /// Could not properly convert the OpenAPI document into a PackageInfo
-    PackageInfoFromOpenAPIError { err: anyhow::Error },
+    #[error("Could not convert the OAS Document into a Package Info file")]
+    PackageInfoFromOpenAPIError { source: anyhow::Error },
 
-    // /// A lock file exists for the current building package, so wait
-    // LockFileExists{ path: PathBuf },
-    // /// Could not create a file lock for system reasons
-    // LockCreateError{ path: PathBuf, err: std::io::Error },
-    // /// Failed to cleanup the .lock file from the build directory after a successfull build.
-    // LockCleanupError{ path: PathBuf, err: std::io::Error },
-    /// Failed to create a LockFile.
-    LockCreateError { name: String, err: brane_shr::fs::Error },
+    #[error("Failed to create lockfile for package '{name}'")]
+    LockCreateError { name: String, source: brane_shr::fs::Error },
 
     /// Could not write to the DockerFile string.
-    DockerfileStrWriteError { err: std::fmt::Error },
+    #[error("Could not write to the internal DockerFile")]
+    DockerfileStrWriteError { source: std::fmt::Error },
     /// A given filepath escaped the working directory
+    #[error("File '{}' tries to escape package working directory; consider moving Brane's working directory up (using --workdir) and avoid '..'", path.display())]
     UnsafePath { path: PathBuf },
     /// The entrypoint executable referenced was not found
+    #[error("Could not find the package entrypoint '{}'", path.display())]
     MissingExecutable { path: PathBuf },
 
     /// Could not create the Dockerfile in the build directory.
-    DockerfileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create Dockerfile '{}'", path.display())]
+    DockerfileCreateError { path: PathBuf, source: std::io::Error },
     /// Could not write to the Dockerfile in the build directory.
-    DockerfileWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Could not write to Dockerfile '{}'", path.display())]
+    DockerfileWriteError { path: PathBuf, source: std::io::Error },
     /// Could not create the container directory
-    ContainerDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create container directory '{}'", path.display())]
+    ContainerDirCreateError { path: PathBuf, source: std::io::Error },
     /// Could not resolve the custom branelet's path
-    BraneletCanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Could not resolve custom init binary path '{}'", path.display())]
+    BraneletCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Could not copy the branelet executable
-    BraneletCopyError { source: PathBuf, target: PathBuf, err: std::io::Error },
+    #[error("Could not copy custom init binary from '{}' to '{}'", original.display(), target.display())]
+    BraneletCopyError { original: PathBuf, target: PathBuf, source: std::io::Error },
     /// Could not clear an existing working directory
-    WdClearError { path: PathBuf, err: std::io::Error },
+    #[error("Could not clear existing package working directory '{}'", path.display())]
+    WdClearError { path: PathBuf, source: std::io::Error },
     /// Could not create a new working directory
-    WdCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create package working directory '{}'", path.display())]
+    WdCreateError { path: PathBuf, source: std::io::Error },
     /// Could not write the LocalContainerInfo to the container directory.
-    LocalContainerInfoCreateError { err: LocalContainerInfoError },
+    #[error("Could not write local container info to container directory")]
+    LocalContainerInfoCreateError { source: LocalContainerInfoError },
     /// Could not canonicalize file's path that will be copied to the working directory
-    WdSourceFileCanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Could not resolve file '{}' in the package info file", path.display())]
+    WdSourceFileCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Could not canonicalize a workdir file's path
-    WdTargetFileCanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Could not resolve file '{}' in the package working directory", path.display())]
+    WdTargetFileCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Could not create a directory in the working directory
-    WdDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create directory '{}' in the package working directory", path.display())]
+    WdDirCreateError { path: PathBuf, source: std::io::Error },
     /// Could not copy a file to the working directory
-    WdFileCopyError { source: PathBuf, target: PathBuf, err: std::io::Error },
+    #[error("Could not copy file '{}' to '{}' in the package working directory", original.display(), target.display())]
+    WdFileCopyError { original: PathBuf, target: PathBuf, source: std::io::Error },
     /// Could not read a directory's entries.
-    WdDirReadError { path: PathBuf, err: std::io::Error },
+    #[error("Could not read directory '{}' in the package working directory", path.display())]
+    WdDirReadError { path: PathBuf, source: std::io::Error },
     /// Could not unwrap an entry in a directory.
-    WdDirEntryError { path: PathBuf, err: std::io::Error },
+    #[error("Could not read entry in directory '{}' in the package working directory", path.display())]
+    WdDirEntryError { path: PathBuf, source: std::io::Error },
     /// Could not rename a file.
-    WdFileRenameError { source: PathBuf, target: PathBuf, err: std::io::Error },
+    #[error("Could not rename file '{}' to '{}' in the package working directory", original.display(), target.display())]
+    WdFileRenameError { original: PathBuf, target: PathBuf, source: std::io::Error },
     /// Failed to create a new file.
-    WdFileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create new file '{}' in the package working directory", path.display())]
+    WdFileCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to open a file.
-    WdFileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Could not open file '{}' in the package working directory", path.display())]
+    WdFileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read a file.
-    WdFileReadError { path: PathBuf, err: std::io::Error },
+    #[error("Could not read from file '{}' in the package working directory", path.display())]
+    WdFileReadError { path: PathBuf, source: std::io::Error },
     /// Failed to write to a file.
-    WdFileWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Could not write to file '{}' in the package working directory", path.display())]
+    WdFileWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to remove a file.
-    WdFileRemoveError { path: PathBuf, err: std::io::Error },
+    #[error("Could not remove file '{}' in the package working directory", path.display())]
+    WdFileRemoveError { path: PathBuf, source: std::io::Error },
     /// Could not launch the command to compress the working directory
-    WdCompressionLaunchError { command: String, err: std::io::Error },
+    #[error("Could not run command '{command}' to compress working directory")]
+    WdCompressionLaunchError { command: String, source: std::io::Error },
     /// Command to compress the working directory returned a non-zero exit code
+    #[error("Command '{}' to compress working directory returned exit code {}:\n\nstdout:\n{}\n{}\n{}\n\nstderr:\n{}\n{}\n{}\n\n", command, code, *CLI_LINE_SEPARATOR, stdout, *CLI_LINE_SEPARATOR, *CLI_LINE_SEPARATOR, stderr, *CLI_LINE_SEPARATOR)]
     WdCompressionError { command: String, code: i32, stdout: String, stderr: String },
     /// Failed to ask the user for consent.
-    WdConfirmationError { err: dialoguer::Error },
+    #[error("Failed to ask the user (you!) for consent")]
+    WdConfirmationError { source: dialoguer::Error },
 
     /// Could not serialize the OPenAPI file
-    OpenAPISerializeError { err: serde_yaml::Error },
+    #[error("Could not re-serialize OpenAPI document")]
+    OpenAPISerializeError { source: serde_yaml::Error },
     /// COuld not create a new OpenAPI file
-    OpenAPIFileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create OpenAPI file '{}'", path.display())]
+    OpenAPIFileCreateError { path: PathBuf, source: std::io::Error },
     /// Could not write to a new OpenAPI file
-    OpenAPIFileWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Could not write to OpenAPI file '{}'", path.display())]
+    OpenAPIFileWriteError { path: PathBuf, source: std::io::Error },
 
-    // /// Could not create a file within the package directory
-    // PackageFileCreateError{ path: PathBuf, err: std::io::Error },
-    // /// Could not write to a file within the package directory
-    // PackageFileWriteError{ path: PathBuf, err: std::io::Error },
-    // /// Could not serialize the ContainerInfo back to text.
-    // ContainerInfoSerializeError{ err: serde_yaml::Error },
-    // /// Could not serialize the LocalContainerInfo back to text.
-    // LocalContainerInfoSerializeError{ err: serde_yaml::Error },
-    // /// Could not serialize the OpenAPI document back to text.
-    // OpenAPISerializeError{ err: serde_yaml::Error },
-    // /// Could not serialize the PackageInfo.
-    // PackageInfoSerializeError{ err: serde_yaml::Error },
     /// Could not launch the command to see if buildkit is installed
-    BuildKitLaunchError { command: String, err: std::io::Error },
+    #[error("Could not determine if Docker & BuildKit are installed: failed to run command '{command}'")]
+    BuildKitLaunchError { command: String, source: std::io::Error },
     /// The simple command to instantiate/test the BuildKit plugin for Docker returned a non-success
+    #[error("Could not run a Docker BuildKit (command '{}' returned exit code {}): is BuildKit installed?\n\nstdout:\n{}\n{}\n{}\n\nstderr:\n{}\n{}\n{}\n\n", command, code, *CLI_LINE_SEPARATOR, stdout, *CLI_LINE_SEPARATOR, *CLI_LINE_SEPARATOR, stderr, *CLI_LINE_SEPARATOR)]
     BuildKitError { command: String, code: i32, stdout: String, stderr: String },
     /// Could not launch the command to build the package image
-    ImageBuildLaunchError { command: String, err: std::io::Error },
+    #[error("Could not run command '{command}' to build the package image")]
+    ImageBuildLaunchError { command: String, source: std::io::Error },
     /// The command to build the image returned a non-zero exit code (we don't accept stdout or stderr here, as the command's output itself will be passed to stdout & stderr)
+    #[error("Command '{command}' to build the package image returned exit code {code}")]
     ImageBuildError { command: String, code: i32 },
 
     /// Could not get the digest from the just-built image
-    DigestError { err: brane_tsk::docker::Error },
+    #[error("Could not get Docker image digest")]
+    DigestError { source: brane_tsk::docker::Error },
     /// Could not write the PackageFile to the build directory.
-    PackageFileCreateError { err: PackageInfoError },
+    #[error("Could not write package info to build directory")]
+    PackageFileCreateError { source: PackageInfoError },
 
-    // /// Failed to remove an existing build of this package/version from the docker daemon
-    // DockerCleanupError{ image: String, err: ExecutorError },
     /// Failed to cleanup a file from the build directory after a successfull build.
-    FileCleanupError { path: PathBuf, err: std::io::Error },
+    #[error("Could not clean file '{}' from build directory", path.display())]
+    FileCleanupError { path: PathBuf, source: std::io::Error },
     /// Failed to cleanup a directory from the build directory after a successfull build.
-    DirCleanupError { path: PathBuf, err: std::io::Error },
+    #[error("Could not clean directory '{}' from build directory", path.display())]
+    DirCleanupError { path: PathBuf, source: std::io::Error },
     /// Failed to cleanup the build directory after a failed build.
-    CleanupError { path: PathBuf, err: std::io::Error },
+    #[error("Could not clean build directory '{}'", path.display())]
+    CleanupError { path: PathBuf, source: std::io::Error },
 
     /// Could not open the just-build image.tar
-    ImageTarOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Could not open the built image.tar ('{}')", path.display())]
+    ImageTarOpenError { path: PathBuf, source: std::io::Error },
     /// Could not get the entries in the image.tar
-    ImageTarEntriesError { path: PathBuf, err: std::io::Error },
+    #[error("Could get entries in the built image.tar ('{}')", path.display())]
+    ImageTarEntriesError { path: PathBuf, source: std::io::Error },
     /// Could not parse the extracted manifest file
-    ManifestParseError { path: PathBuf, err: serde_json::Error },
+    #[error("Could not parse extracted Docker manifest '{}'", path.display())]
+    ManifestParseError { path: PathBuf, source: serde_json::Error },
     /// The number of entries in the given manifest is not one (?)
+    #[error("Extracted Docker manifest '{}' has an incorrect number of entries: got {}, expected 1", path.display(), n)]
     ManifestNotOneEntry { path: PathBuf, n: usize },
     /// The path to the config blob (which contains Docker's digest) is invalid
+    #[error("Extracted Docker manifest '{}' has an incorrect path to the config blob: got {}, expected it to start with 'blobs/sha256/'", path.display(), config)]
     ManifestInvalidConfigBlob { path: PathBuf, config: String },
     /// Didn't find any manifest.json in the image.tar
+    #[error("Built image.tar ('{}') does not contain a manifest.json", path.display())]
     NoManifest { path: PathBuf },
     /// Could not create the resulting digest.txt file
-    DigestFileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not open digest file '{}'", path.display())]
+    DigestFileCreateError { path: PathBuf, source: std::io::Error },
     /// Could not write to the resulting digest.txt file
-    DigestFileWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Could not write to digest file '{}'", path.display())]
+    DigestFileWriteError { path: PathBuf, source: std::io::Error },
 
     /// Could not get the host architecture
-    HostArchError { err: specifications::arch::ArchError },
+    #[error("Could not get host architecture")]
+    HostArchError { source: specifications::arch::ArchError },
 }
-impl Display for BuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use BuildError::*;
-        match self {
-            ContainerInfoOpenError { file, .. } => write!(f, "Could not open the container info file '{}'", file.display()),
-            ContainerInfoParseError { file, .. } => write!(f, "Could not parse the container info file '{}'", file.display()),
-            PackageDirError { .. } => write!(f, "Could not create package directory"),
-
-            OasDocumentParseError { file, .. } => write!(f, "Could not parse the OAS Document '{}'", file.display()),
-            VersionParseError { .. } => write!(f, "Could not parse OAS Document version number"),
-            PackageInfoFromOpenAPIError { .. } => write!(f, "Could not convert the OAS Document into a Package Info file"),
-
-            // LockFileExists{ path }        => write!(f, "The build directory '{}' is busy; try again later (a lock file exists)", path.display()),
-            // LockCreateError{ path, .. }  => write!(f, "Could not create lock file '{}'", path.display()),
-            // LockCleanupError{ path, .. } => write!(f, "Could not clean the lock file ('{}') from build directory", path.display()),
-            LockCreateError { name, .. } => write!(f, "Failed to create lockfile for package '{name}'"),
-
-            DockerfileStrWriteError { .. } => write!(f, "Could not write to the internal DockerFile"),
-            UnsafePath { path } => write!(
-                f,
-                "File '{}' tries to escape package working directory; consider moving Brane's working directory up (using --workdir) and avoid '..'",
-                path.display()
-            ),
-            MissingExecutable { path } => write!(f, "Could not find the package entrypoint '{}'", path.display()),
-
-            DockerfileCreateError { path, .. } => write!(f, "Could not create Dockerfile '{}'", path.display()),
-            DockerfileWriteError { path, .. } => write!(f, "Could not write to Dockerfile '{}'", path.display()),
-            ContainerDirCreateError { path, .. } => write!(f, "Could not create container directory '{}'", path.display()),
-            BraneletCanonicalizeError { path, .. } => write!(f, "Could not resolve custom init binary path '{}'", path.display()),
-            BraneletCopyError { source, target, .. } => {
-                write!(f, "Could not copy custom init binary from '{}' to '{}'", source.display(), target.display())
-            },
-            WdClearError { path, .. } => write!(f, "Could not clear existing package working directory '{}'", path.display()),
-            WdCreateError { path, .. } => write!(f, "Could not create package working directory '{}'", path.display()),
-            LocalContainerInfoCreateError { .. } => write!(f, "Could not write local container info to container directory"),
-            WdSourceFileCanonicalizeError { path, .. } => write!(f, "Could not resolve file '{}' in the package info file", path.display()),
-            WdTargetFileCanonicalizeError { path, .. } => {
-                write!(f, "Could not resolve file '{}' in the package working directory", path.display())
-            },
-            WdDirCreateError { path, .. } => write!(f, "Could not create directory '{}' in the package working directory", path.display()),
-            WdDirEntryError { path, .. } => {
-                write!(f, "Could not read entry in directory '{}' in the package working directory", path.display())
-            },
-            WdDirReadError { path, .. } => write!(f, "Could not read directory '{}' in the package working directory", path.display()),
-            WdFileCopyError { source, target, .. } => {
-                write!(f, "Could not copy file '{}' to '{}' in the package working directory", source.display(), target.display())
-            },
-            WdFileRenameError { source, target, .. } => {
-                write!(f, "Could not rename file '{}' to '{}' in the package working directory", source.display(), target.display())
-            },
-            WdFileCreateError { path, .. } => write!(f, "Could not create new file '{}' in the package working directory", path.display()),
-            WdFileOpenError { path, .. } => write!(f, "Could not open file '{}' in the package working directory", path.display()),
-            WdFileReadError { path, .. } => write!(f, "Could not read from file '{}' in the package working directory", path.display()),
-            WdFileWriteError { path, .. } => write!(f, "Could not write to file '{}' in the package working directory", path.display()),
-            WdFileRemoveError { path, .. } => write!(f, "Could not remove file '{}' in the package working directory", path.display()),
-            WdCompressionLaunchError { command, .. } => write!(f, "Could not run command '{command}' to compress working directory"),
-            WdCompressionError { command, code, stdout, stderr } => write!(
-                f,
-                "Command '{}' to compress working directory returned exit code {}:\n\nstdout:\n{}\n{}\n{}\n\nstderr:\n{}\n{}\n{}\n\n",
-                command, code, *CLI_LINE_SEPARATOR, stdout, *CLI_LINE_SEPARATOR, *CLI_LINE_SEPARATOR, stderr, *CLI_LINE_SEPARATOR
-            ),
-            WdConfirmationError { .. } => write!(f, "Failed to ask the user (you!) for consent"),
-
-            OpenAPISerializeError { .. } => write!(f, "Could not re-serialize OpenAPI document"),
-            OpenAPIFileCreateError { path, .. } => write!(f, "Could not create OpenAPI file '{}'", path.display()),
-            OpenAPIFileWriteError { path, .. } => write!(f, "Could not write to OpenAPI file '{}'", path.display()),
-
-            // PackageFileCreateError{ path, .. }     => write!(f, "Could not create file '{}' within the package directory", path.display()),
-            // PackageFileWriteError{ path, .. }      => write!(f, "Could not write to file '{}' within the package directory", path.display()),
-            // ContainerInfoSerializeError{ .. }      => write!(f, "Could not re-serialize container.yml: {}", err),
-            // LocalContainerInfoSerializeError{ .. } => write!(f, "Could not re-serialize container.yml as local_container.yml: {}", err),
-            // PackageInfoSerializeError{ .. }        => write!(f, "Could not serialize generated package info file: {}", err),
-            BuildKitLaunchError { command, .. } => {
-                write!(f, "Could not determine if Docker & BuildKit are installed: failed to run command '{command}'")
-            },
-            BuildKitError { command, code, stdout, stderr } => write!(
-                f,
-                "Could not run a Docker BuildKit (command '{}' returned exit code {}): is BuildKit \
-                 installed?\n\nstdout:\n{}\n{}\n{}\n\nstderr:\n{}\n{}\n{}\n\n",
-                command, code, *CLI_LINE_SEPARATOR, stdout, *CLI_LINE_SEPARATOR, *CLI_LINE_SEPARATOR, stderr, *CLI_LINE_SEPARATOR
-            ),
-            ImageBuildLaunchError { command, .. } => write!(f, "Could not run command '{command}' to build the package image"),
-            ImageBuildError { command, code } => write!(f, "Command '{command}' to build the package image returned exit code {code}"),
-
-            DigestError { .. } => write!(f, "Could not get Docker image digest"),
-            PackageFileCreateError { .. } => write!(f, "Could not write package info to build directory"),
-
-            // BuildError::DockerCleanupError{ image, .. } => write!(f, "Could not remove existing image '{}' from docker daemon", image),
-            FileCleanupError { path, .. } => write!(f, "Could not clean file '{}' from build directory", path.display()),
-            DirCleanupError { path, .. } => write!(f, "Could not clean directory '{}' from build directory", path.display()),
-            CleanupError { path, .. } => write!(f, "Could not clean build directory '{}'", path.display()),
-
-            ImageTarOpenError { path, .. } => write!(f, "Could not open the built image.tar ('{}')", path.display()),
-            ImageTarEntriesError { path, .. } => write!(f, "Could get entries in the built image.tar ('{}')", path.display()),
-            ManifestParseError { path, .. } => write!(f, "Could not parse extracted Docker manifest '{}'", path.display()),
-            ManifestNotOneEntry { path, n } => {
-                write!(f, "Extracted Docker manifest '{}' has an incorrect number of entries: got {}, expected 1", path.display(), n)
-            },
-            ManifestInvalidConfigBlob { path, config } => write!(
-                f,
-                "Extracted Docker manifest '{}' has an incorrect path to the config blob: got {}, expected it to start with 'blobs/sha256/'",
-                path.display(),
-                config
-            ),
-            NoManifest { path } => write!(f, "Built image.tar ('{}') does not contain a manifest.json", path.display()),
-            DigestFileCreateError { path, .. } => write!(f, "Could not open digest file '{}'", path.display()),
-            DigestFileWriteError { path, .. } => write!(f, "Could not write to digest file '{}'", path.display()),
-
-            HostArchError { .. } => write!(f, "Could not get host architecture"),
-        }
-    }
-}
-impl Error for BuildError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use BuildError::*;
-        match self {
-            ContainerInfoOpenError { err, .. } => Some(err),
-            ContainerInfoParseError { err, .. } => Some(err),
-            PackageDirError { err } => Some(err),
-
-            OasDocumentParseError { err, .. } => Some(&**err),
-            VersionParseError { err } => Some(err),
-            PackageInfoFromOpenAPIError { err } => Some(&**err),
-
-            LockCreateError { err, .. } => Some(err),
-
-            DockerfileStrWriteError { err, .. } => Some(err),
-            UnsafePath { .. } => None,
-            MissingExecutable { .. } => None,
-
-            DockerfileCreateError { err, .. } => Some(err),
-            DockerfileWriteError { err, .. } => Some(err),
-            ContainerDirCreateError { err, .. } => Some(err),
-            BraneletCanonicalizeError { err, .. } => Some(err),
-            BraneletCopyError { err, .. } => Some(err),
-            WdClearError { err, .. } => Some(err),
-            WdCreateError { err, .. } => Some(err),
-            LocalContainerInfoCreateError { err } => Some(err),
-            WdSourceFileCanonicalizeError { err, .. } => Some(err),
-            WdTargetFileCanonicalizeError { err, .. } => Some(err),
-            WdDirCreateError { err, .. } => Some(err),
-            WdFileCopyError { err, .. } => Some(err),
-            WdDirReadError { err, .. } => Some(err),
-            WdDirEntryError { err, .. } => Some(err),
-            WdFileRenameError { err, .. } => Some(err),
-            WdFileCreateError { err, .. } => Some(err),
-            WdFileOpenError { err, .. } => Some(err),
-            WdFileReadError { err, .. } => Some(err),
-            WdFileWriteError { err, .. } => Some(err),
-            WdFileRemoveError { err, .. } => Some(err),
-            WdCompressionLaunchError { err, .. } => Some(err),
-            WdCompressionError { .. } => None,
-            WdConfirmationError { err } => Some(err),
-
-            OpenAPISerializeError { err } => Some(err),
-            OpenAPIFileCreateError { err, .. } => Some(err),
-            OpenAPIFileWriteError { err, .. } => Some(err),
-
-            BuildKitLaunchError { err, .. } => Some(err),
-            BuildKitError { .. } => None,
-            ImageBuildLaunchError { err, .. } => Some(err),
-            ImageBuildError { .. } => None,
-
-            DigestError { err } => Some(err),
-            PackageFileCreateError { err } => Some(err),
-
-            FileCleanupError { err, .. } => Some(err),
-            DirCleanupError { err, .. } => Some(err),
-            CleanupError { err, .. } => Some(err),
-
-            ImageTarOpenError { err, .. } => Some(err),
-            ImageTarEntriesError { err, .. } => Some(err),
-            ManifestParseError { err, .. } => Some(err),
-            ManifestNotOneEntry { .. } => None,
-            ManifestInvalidConfigBlob { .. } => None,
-            NoManifest { .. } => None,
-            DigestFileCreateError { err, .. } => Some(err),
-            DigestFileWriteError { err, .. } => Some(err),
-
-            HostArchError { err } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors relating to certificate management.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CertsError {
     /// The active instance file exists but is not a softlink.
+    #[error("Active instance link '{}' exists but is not a symlink", path.display())]
     ActiveInstanceNotASoftlinkError { path: PathBuf },
 
     /// Failed to parse the name in a certificate.
-    CertParseError { path: PathBuf, i: usize, err: x509_parser::nom::Err<x509_parser::error::X509Error> },
+    #[error("Failed to parse certificate {} in file '{}'", i, path.display())]
+    CertParseError { path: PathBuf, i: usize, source: x509_parser::nom::Err<x509_parser::error::X509Error> },
     /// Failed to get the extensions from the given certificate.
-    CertExtensionsError { path: PathBuf, i: usize, err: x509_parser::error::X509Error },
+    #[error("Failed to get extensions in certificate {} in file '{}'", i, path.display())]
+    CertExtensionsError { path: PathBuf, i: usize, source: x509_parser::error::X509Error },
     /// Did not find the key usage extension in the given certificate.
+    #[error("Certificate {} in file '{}' does not have key usage defined (extension)", i, path.display())]
     CertNoKeyUsageError { path: PathBuf, i: usize },
     /// The given certificate had an ambigious key usage flag set.
+    #[error("Certificate {} in file '{}' has both Digital Signature and CRL Sign flags set (ambigious usage)", i, path.display())]
     CertAmbigiousUsageError { path: PathBuf, i: usize },
     /// The given certificate had no (valid) key usage flag set.
+    #[error("Certificate {} in file '{}' has neither Digital Signature, nor CRL Sign flags set (cannot determine usage)", i, path.display())]
     CertNoUsageError { path: PathBuf, i: usize },
     /// Failed to get the issuer CA string.
-    CertIssuerCaError { path: PathBuf, i: usize, err: x509_parser::error::X509Error },
+    #[error("Failed to get the CA field in the issuer field of certificate {} in file '{}'", i, path.display())]
+    CertIssuerCaError { path: PathBuf, i: usize, source: x509_parser::error::X509Error },
 
     /// Failed to load instance directory.
-    InstanceDirError { err: UtilError },
+    #[error("Failed to get instance directory")]
+    InstanceDirError { source: UtilError },
     /// An unknown instance was given.
+    #[error("Unknown instance '{name}'")]
     UnknownInstance { name: String },
     /// Failed to read the directory behind the active instance link.
-    ActiveInstanceReadError { err: InstanceError },
+    #[error("Failed to read active instance")]
+    ActiveInstanceReadError { source: InstanceError },
     /// Failed to get the path behind an instance name.
-    InstancePathError { name: String, err: InstanceError },
+    #[error("Failed to get instance path for instance '{name}'")]
+    InstancePathError { name: String, source: InstanceError },
     /// Did not manage to load (one of) the given PEM files.
-    PemLoadError { path: PathBuf, err: brane_cfg::certs::Error },
+    #[error("Failed to load PEM file '{}'", path.display())]
+    PemLoadError { path: PathBuf, source: brane_cfg::certs::Error },
     /// No CA certificate was provided.
+    #[error("No CA certificate given (specify at least one certificate that has 'CRL Sign' key usage flag set)")]
     NoCaCert,
     /// No client certificate was provided.
+    #[error("No client certificate given (specify at least one certificate that has 'Digital Signature' key usage flag set)")]
     NoClientCert,
     /// The no client key was provided.
+    #[error("No client private key given (specify at least one private key)")]
     NoClientKey,
     /// No domain name found in the certificates.
+    #[error("Location name not specified in certificates; specify the target location name manually using '--domain'")]
     NoDomainName,
     /// Failed to ask the user for confirmation.
-    ConfirmationError { err: dialoguer::Error },
+    #[error("Failed to ask the user (you!) for confirmation (if you are sure, you can skip this step by using '--force')")]
+    ConfirmationError { source: dialoguer::Error },
     /// The given certs directory existed but was not a directory.
+    #[error("Certificate directory '{}' exists but is not a directory", path.display())]
     CertsDirNotADir { path: PathBuf },
     /// Failed to remove the certificates directory.
-    CertsDirRemoveError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to remove certificate directory '{}'", path.display())]
+    CertsDirRemoveError { path: PathBuf, source: std::io::Error },
     /// Failed to create the certificates directory.
-    CertsDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create certificate directory '{}'", path.display())]
+    CertsDirCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to open the given file in append mode.
-    FileOpenError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to open {} file '{}' for appending", what, path.display())]
+    FileOpenError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to write to the given file.
-    FileWriteError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to {} file '{}'", what, path.display())]
+    FileWriteError { what: &'static str, path: PathBuf, source: std::io::Error },
 
     /// Failed to load instances directory.
-    InstancesDirError { err: UtilError },
+    #[error("Failed to get instances directory")]
+    InstancesDirError { source: UtilError },
     /// Failed to read the directory with instances.
-    DirReadError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to read {} directory '{}'", what, path.display())]
+    DirReadError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to read a specific entry within the directory with instances.
-    DirEntryReadError { what: &'static str, path: PathBuf, entry: usize, err: std::io::Error },
+    #[error("Failed to read entry {} in {} directory '{}'", entry, what, path.display())]
+    DirEntryReadError { what: &'static str, path: PathBuf, entry: usize, source: std::io::Error },
 }
-impl Display for CertsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use CertsError::*;
-        match self {
-            ActiveInstanceNotASoftlinkError { path } => write!(f, "Active instance link '{}' exists but is not a symlink", path.display()),
-
-            CertParseError { path, i, .. } => write!(f, "Failed to parse certificate {} in file '{}'", i, path.display()),
-            CertExtensionsError { path, i, .. } => write!(f, "Failed to get extensions in certificate {} in file '{}'", i, path.display()),
-            CertNoKeyUsageError { path, i } => {
-                write!(f, "Certificate {} in file '{}' does not have key usage defined (extension)", i, path.display())
-            },
-            CertAmbigiousUsageError { path, i } => {
-                write!(f, "Certificate {} in file '{}' has both Digital Signature and CRL Sign flags set (ambigious usage)", i, path.display())
-            },
-            CertNoUsageError { path, i } => write!(
-                f,
-                "Certificate {} in file '{}' has neither Digital Signature, nor CRL Sign flags set (cannot determine usage)",
-                i,
-                path.display()
-            ),
-            CertIssuerCaError { path, i, .. } => {
-                write!(f, "Failed to get the CA field in the issuer field of certificate {} in file '{}'", i, path.display())
-            },
-
-            InstanceDirError { .. } => write!(f, "Failed to get instance directory"),
-            UnknownInstance { name } => write!(f, "Unknown instance '{name}'"),
-            ActiveInstanceReadError { .. } => write!(f, "Failed to read active instance"),
-            InstancePathError { name, .. } => write!(f, "Failed to get instance path for instance '{name}'"),
-            PemLoadError { path, .. } => write!(f, "Failed to load PEM file '{}'", path.display()),
-            NoCaCert => write!(f, "No CA certificate given (specify at least one certificate that has 'CRL Sign' key usage flag set)"),
-            NoClientCert => {
-                write!(f, "No client certificate given (specify at least one certificate that has 'Digital Signature' key usage flag set)")
-            },
-            NoClientKey => write!(f, "No client private key given (specify at least one private key)"),
-            NoDomainName => write!(f, "Location name not specified in certificates; specify the target location name manually using '--domain'"),
-            ConfirmationError { .. } => {
-                write!(f, "Failed to ask the user (you!) for confirmation (if you are sure, you can skip this step by using '--force')")
-            },
-            CertsDirNotADir { path } => write!(f, "Certificate directory '{}' exists but is not a directory", path.display()),
-            CertsDirRemoveError { path, .. } => write!(f, "Failed to remove certificate directory '{}'", path.display()),
-            CertsDirCreateError { path, .. } => write!(f, "Failed to create certificate directory '{}'", path.display()),
-            FileOpenError { what, path, .. } => write!(f, "Failed to open {} file '{}' for appending", what, path.display()),
-            FileWriteError { what, path, .. } => write!(f, "Failed to write to {} file '{}'", what, path.display()),
-
-            InstancesDirError { .. } => write!(f, "Failed to get instances directory"),
-            DirReadError { what, path, .. } => write!(f, "Failed to read {} directory '{}'", what, path.display()),
-            DirEntryReadError { what, path, entry, .. } => {
-                write!(f, "Failed to read entry {} in {} directory '{}'", entry, what, path.display())
-            },
-        }
-    }
-}
-impl Error for CertsError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use CertsError::*;
-        match self {
-            ActiveInstanceNotASoftlinkError { .. } => None,
-
-            CertParseError { err, .. } => Some(err),
-            CertExtensionsError { err, .. } => Some(err),
-            CertNoKeyUsageError { .. } => None,
-            CertAmbigiousUsageError { .. } => None,
-            CertNoUsageError { .. } => None,
-            CertIssuerCaError { err, .. } => Some(err),
-
-            InstanceDirError { err } => Some(err),
-            UnknownInstance { .. } => None,
-            ActiveInstanceReadError { err } => Some(err),
-            InstancePathError { err, .. } => Some(err),
-            PemLoadError { err, .. } => Some(err),
-            NoCaCert => None,
-            NoClientCert => None,
-            NoClientKey => None,
-            NoDomainName => None,
-            ConfirmationError { err } => Some(err),
-            CertsDirNotADir { .. } => None,
-            CertsDirRemoveError { err, .. } => Some(err),
-            CertsDirCreateError { err, .. } => Some(err),
-            FileOpenError { err, .. } => Some(err),
-            FileWriteError { err, .. } => Some(err),
-
-            InstancesDirError { err } => Some(err),
-            DirReadError { err, .. } => Some(err),
-            DirEntryReadError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Defines errors originating from the `brane check`-subcommand.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CheckError {
     /// Failed to load the active instance info file.
-    ActiveInstanceInfoLoad { err: InstanceError },
+    #[error("Failed to get currently active instance")]
+    ActiveInstanceInfoLoad { source: InstanceError },
     /// The compile step from `brane_ast` failed.
+    #[error("Failed to compile workflow '{input}' (see output above)")]
     AstCompile { input: String },
     /// Failed to retrieve the data index.
-    DataIndexRetrieve { url: String, err: brane_tsk::api::Error },
+    #[error("Failed to retrieve data index from '{url}'")]
+    DataIndexRetrieve { url: String, source: brane_tsk::api::Error },
     /// The Driver failed to check.
-    DriverCheck { address: Address, err: tonic::Status },
+    #[error("Failed to send CheckRequest to driver '{address}'")]
+    DriverCheck { address: Address, source: tonic::Status },
     /// Failed to connect to the driver.
-    DriverConnect { address: Address, err: specifications::driving::DriverServiceError },
+    #[error("Failed to connect to driver '{address}'")]
+    DriverConnect { address: Address, source: specifications::driving::DriverServiceError },
     /// Failed to read the input from the given file.
-    InputFileRead { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read input file '{}'", path.display())]
+    InputFileRead { path: PathBuf, source: std::io::Error },
     /// Failed to read the input from stdin.
-    InputStdinRead { err: std::io::Error },
+    #[error("Failed to read input from stdin")]
+    InputStdinRead { source: std::io::Error },
     /// Failed to retrieve the package index.
-    PackageIndexRetrieve { url: String, err: brane_tsk::api::Error },
+    #[error("Failed to retrieve package index from '{url}'")]
+    PackageIndexRetrieve { url: String, source: brane_tsk::api::Error },
     /// Failed to compile a given workflow.
-    WorkflowCompile { input: String, err: Box<Self> },
+    #[error("Failed to compile workflow '{input}'")]
+    WorkflowCompile { input: String, source: Box<Self> },
     /// Failed to serialize the compiled workflow.
-    WorkflowSerialize { input: String, err: serde_json::Error },
+    #[error("Failed to serialize workflow '{input}'")]
+    WorkflowSerialize { input: String, source: serde_json::Error },
 }
-impl Display for CheckError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use CheckError::*;
-        match self {
-            ActiveInstanceInfoLoad { .. } => write!(f, "Failed to get currently active instance"),
-            AstCompile { input } => write!(f, "Failed to compile workflow '{input}' (see output above)"),
-            DataIndexRetrieve { url, .. } => write!(f, "Failed to retrieve data index from '{url}'"),
-            DriverCheck { address, .. } => write!(f, "Failed to send CheckRequest to driver '{address}'"),
-            DriverConnect { address, .. } => write!(f, "Failed to connect to driver '{address}'"),
-            InputFileRead { path, .. } => write!(f, "Failed to read input file '{}'", path.display()),
-            InputStdinRead { .. } => write!(f, "Failed to read input from stdin"),
-            PackageIndexRetrieve { url, .. } => write!(f, "Failed to retrieve package index from '{url}'"),
-            WorkflowCompile { input, .. } => write!(f, "Failed to compile workflow '{input}'"),
-            WorkflowSerialize { input, .. } => write!(f, "Failed to serialize workflow '{input}'"),
-        }
-    }
-}
-impl Error for CheckError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use CheckError::*;
-        match self {
-            ActiveInstanceInfoLoad { err } => Some(err),
-            AstCompile { .. } => None,
-            DataIndexRetrieve { err, .. } => Some(err),
-            DriverCheck { err, .. } => Some(err),
-            DriverConnect { err, .. } => Some(err),
-            InputFileRead { err, .. } => Some(err),
-            InputStdinRead { err } => Some(err),
-            PackageIndexRetrieve { err, .. } => Some(err),
-            WorkflowCompile { err, .. } => Some(err),
-            WorkflowSerialize { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors during the build subcommand
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DataError {
     /// Failed to sent the GET-request to fetch the dfelegate.
-    RequestError {
-        what:    &'static str,
-        address: String,
-        err:     reqwest::Error,
-    },
+    #[error("Failed to send {what} request to '{address}'")]
+    RequestError { what: &'static str, address: String, source: reqwest::Error },
     /// The request returned a non-2xx status code.
-    RequestFailure {
-        address: String,
-        code:    StatusCode,
-        message: Option<String>,
-    },
+    #[error("Request to '{}' failed with status code {} ({}){}", address, code, code.canonical_reason().unwrap_or("???"), if let Some(msg) = message { format!(": {msg}") } else { String::new() })]
+    RequestFailure { address: String, code: StatusCode, message: Option<String> },
     /// Failed to get the request body properly.
-    ResponseTextError {
-        address: String,
-        err:     reqwest::Error,
-    },
-    // /// Failed to load the keypair.
-    // KeypairLoadError{ err: brane_cfg::certs::Error },
-    // /// Failed to load the certificate root store.
-    // StoreLoadError{ err: brane_cfg::certs::Error },
+    #[error("Failed to get body from response sent by '{address}' as text")]
+    ResponseTextError { address: String, source: reqwest::Error },
     /// Failed to open/read a given file.
-    FileReadError {
-        what: &'static str,
-        path: PathBuf,
-        err:  std::io::Error,
-    },
+    #[error("Failed to read {} file '{}'", what, path.display())]
+    FileReadError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to get the directory of the certificates.
-    CertsDirError {
-        err: CertsError,
-    },
+    #[error("Failed to get certificates directory for active instance")]
+    CertsDirError { source: CertsError },
     /// Failed to parse an identity file.
-    IdentityFileError {
-        path: PathBuf,
-        err:  reqwest::Error,
-    },
+    #[error("Failed to parse identity file '{}'", path.display())]
+    IdentityFileError { path: PathBuf, source: reqwest::Error },
     /// Failed to parse a certificate.
-    CertificateError {
-        path: PathBuf,
-        err:  reqwest::Error,
-    },
+    #[error("Failed to parse certificate '{}'", path.display())]
+    CertificateError { path: PathBuf, source: reqwest::Error },
     /// A directory was not a directory but a file.
-    DirNotADirError {
-        what: &'static str,
-        path: PathBuf,
-    },
+    #[error("{} directory '{}' is not a directory", what, path.display())]
+    DirNotADirError { what: &'static str, path: PathBuf },
     /// A directory could not be removed.
-    DirRemoveError {
-        what: &'static str,
-        path: PathBuf,
-        err:  std::io::Error,
-    },
+    #[error("Failed to remove {} directory '{}'", what, path.display())]
+    DirRemoveError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// A directory could not be created.
-    DirCreateError {
-        what: &'static str,
-        path: PathBuf,
-        err:  std::io::Error,
-    },
-    // /// The given certificate file was empty.
-    // EmptyCertFile{ path: PathBuf },
-    // /// Failed to parse the given key/cert pair as an IdentityFile.
-    // IdentityFileError{ certfile: PathBuf, keyfile: PathBuf, err: reqwest::Error },
-    // /// Failed to load the given certificate as PEM root certificate.
-    // RootError{ cafile: PathBuf, err: reqwest::Error },
+    #[error("Failed to create {} directory '{}'", what, path.display())]
+    DirCreateError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to create a temporary directory.
-    TempDirError {
-        err: std::io::Error,
-    },
+    #[error("Failed to create temporary directory")]
+    TempDirError { source: std::io::Error },
     /// Failed to create the dataset directory.
-    DatasetDirError {
-        name: String,
-        err:  UtilError,
-    },
+    #[error("Failed to create dataset directory for dataset '{name}'")]
+    DatasetDirError { name: String, source: UtilError },
     /// Failed to create a new reqwest proxy
-    ProxyCreateError {
-        address: String,
-        err:     reqwest::Error,
-    },
+    #[error("Failed to create new proxy to '{address}'")]
+    ProxyCreateError { address: String, source: reqwest::Error },
     /// Failed to create a new reqwest client
-    ClientCreateError {
-        err: reqwest::Error,
-    },
+    #[error("Failed to create new client")]
+    ClientCreateError { source: reqwest::Error },
     /// Failed to reach the next chunk of data.
-    DownloadStreamError {
-        address: String,
-        err:     reqwest::Error,
-    },
+    #[error("Failed to get next chunk in download stream from '{address}'")]
+    DownloadStreamError { address: String, source: reqwest::Error },
     /// Failed to create the file to which we write the download stream.
-    TarCreateError {
-        path: PathBuf,
-        err:  std::io::Error,
-    },
-    // /// Failed to (re-)open the file to which we've written the download stream.
-    // TarOpenError{ path: PathBuf, err: std::io::Error },
+    #[error("Failed to create tarball file '{}'", path.display())]
+    TarCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the file where we write the download stream.
-    TarWriteError {
-        path: PathBuf,
-        err:  std::io::Error,
-    },
+    #[error("Failed to write to tarball file '{}'", path.display())]
+    TarWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to extract the downloaded tar.
-    TarExtractError {
-        err: brane_shr::fs::Error,
-    },
+    #[error("Failed to extract downloaded archive")]
+    TarExtractError { source: brane_shr::fs::Error },
 
     /// Failed to get the datasets folder
-    DatasetsError {
-        err: UtilError,
-    },
+    #[error("Failed to get datasets folder")]
+    DatasetsError { source: UtilError },
     /// Failed to fetch the local data index.
-    LocalDataIndexError {
-        err: brane_tsk::local::Error,
-    },
+    #[error("Failed to get local data index")]
+    LocalDataIndexError { source: brane_tsk::local::Error },
 
     /// Failed to load the given AssetInfo file.
-    AssetFileError {
-        path: PathBuf,
-        err:  specifications::data::AssetInfoError,
-    },
+    #[error("Failed to load given asset file '{}'", path.display())]
+    AssetFileError { path: PathBuf, source: specifications::data::AssetInfoError },
     /// Could not canonicalize the given (relative) path.
-    FileCanonicalizeError {
-        path: PathBuf,
-        err:  std::io::Error,
-    },
+    #[error("Failed to resolve path '{}'", path.display())]
+    FileCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// The given file does not exist
-    FileNotFoundError {
-        path: PathBuf,
-    },
+    #[error("Referenced file '{}' not found (are you using the correct working directory?)", path.display())]
+    FileNotFoundError { path: PathBuf },
     /// The given file is not a file
-    FileNotAFileError {
-        path: PathBuf,
-    },
+    #[error("Referenced file '{}' is not a file", path.display())]
+    FileNotAFileError { path: PathBuf },
     /// Failed to create the dataset's directory.
-    DatasetDirCreateError {
-        err: UtilError,
-    },
+    #[error("Failed to create target dataset directory in the Brane data folder")]
+    DatasetDirCreateError { source: UtilError },
     /// A dataset with the given name already exists.
-    DuplicateDatasetError {
-        name: String,
-    },
+    #[error("A dataset with the name '{name}' already exists locally")]
+    DuplicateDatasetError { name: String },
     /// Failed to copy the data directory over.
-    DataCopyError {
-        err: brane_shr::fs::Error,
-    },
+    #[error("Failed to data directory")]
+    DataCopyError { source: brane_shr::fs::Error },
     /// Failed to write the DataInfo.
-    DataInfoWriteError {
-        err: specifications::data::DataInfoError,
-    },
+    #[error("Failed to write DataInfo file")]
+    DataInfoWriteError { source: specifications::data::DataInfoError },
 
     /// The given "keypair" was not a keypair at all
-    NoEqualsInKeyPair {
-        raw: String,
-    },
+    #[error("Missing '=' in key/value pair '{raw}'")]
+    NoEqualsInKeyPair { raw: String },
     /// Failed to fetch the login file.
-    InstanceInfoError {
-        err: InstanceError,
-    },
+    #[error("Could not read active instance info file")]
+    InstanceInfoError { source: InstanceError },
     /// Failed to get the path of the active instance.
-    ActiveInstanceReadError {
-        err: InstanceError,
-    },
+    #[error("Failed to read active instance link")]
+    ActiveInstanceReadError { source: InstanceError },
     /// Failed to get the active instance.
-    InstancePathError {
-        name: String,
-        err:  InstanceError,
-    },
+    #[error("Could not get path of instance '{name}'")]
+    InstancePathError { name: String, source: InstanceError },
     /// Failed to create the remote data index.
-    RemoteDataIndexError {
-        address: String,
-        err:     brane_tsk::errors::ApiError,
-    },
+    #[error("Failed to fetch remote data index from '{address}'")]
+    RemoteDataIndexError { address: String, source: brane_tsk::errors::ApiError },
     /// Failed to select the download location in case there are multiple.
-    DataSelectError {
-        err: dialoguer::Error,
-    },
+    #[error("Failed to ask the user (you!) to select a download location")]
+    DataSelectError { source: dialoguer::Error },
     /// We encountered a location we did not know
-    UnknownLocation {
-        name: String,
-    },
+    #[error("Unknown location '{name}'")]
+    UnknownLocation { name: String },
 
     /// The given dataset was unknown to us.
-    UnknownDataset {
-        name: String,
-    },
+    #[error("Unknown dataset '{name}'")]
+    UnknownDataset { name: String },
     /// the given dataset was known but not locally available.
-    UnavailableDataset {
-        name: String,
-        locs: Vec<String>,
-    },
+    #[error("Dataset '{}' is unavailable{}", name, if !locs.is_empty() { format!("; try {} instead", locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")) } else { String::new() })]
+    UnavailableDataset { name: String, locs: Vec<String> },
 
-    // /// Failed to ensure the directory of the given dataset.
-    // DatasetDirError{ err: UtilError },
     /// Failed to ask the user for consent before removing the dataset.
-    ConfirmationError {
-        err: dialoguer::Error,
-    },
+    #[error("Failed to ask the user (you) for confirmation before removing a dataset")]
+    ConfirmationError { source: dialoguer::Error },
     /// Failed to remove the dataset's directory
-    RemoveError {
-        path: PathBuf,
-        err:  std::io::Error,
-    },
-    WorkflowSerializeError {
-        context: String,
-        err:     serde_json::Error,
-    },
+    #[error("Failed to remove dataset directory '{}'", path.display())]
+    RemoveError { path: PathBuf, source: std::io::Error },
+    /// Failed to serialize workflow
+    #[error("Could not serialize workflow when: {context}")]
+    WorkflowSerializeError { context: String, source: serde_json::Error },
 }
-impl Display for DataError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DataError::*;
-        match self {
-            RequestError { what, address, .. } => write!(f, "Failed to send {what} request to '{address}'"),
-            RequestFailure { address, code, message } => write!(
-                f,
-                "Request to '{}' failed with status code {} ({}){}",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(msg) = message { format!(": {msg}") } else { String::new() }
-            ),
-            ResponseTextError { address, .. } => write!(f, "Failed to get body from response sent by '{address}' as text"),
-            // KeypairLoadError{ .. }                          => write!(f, "Failed to load keypair: {}", err),
-            // StoreLoadError{ .. }                            => write!(f, "Failed to load root store: {}", err),
-            FileReadError { what, path, .. } => write!(f, "Failed to read {} file '{}'", what, path.display()),
-            CertsDirError { .. } => write!(f, "Failed to get certificates directory for active instance"),
-            IdentityFileError { path, .. } => write!(f, "Failed to parse identity file '{}'", path.display()),
-            CertificateError { path, .. } => write!(f, "Failed to parse certificate '{}'", path.display()),
-            DirNotADirError { what, path } => write!(f, "{} directory '{}' is not a directory", what, path.display()),
-            DirRemoveError { what, path, .. } => write!(f, "Failed to remove {} directory '{}'", what, path.display()),
-            DirCreateError { what, path, .. } => write!(f, "Failed to create {} directory '{}'", what, path.display()),
-            // EmptyCertFile{ path }                            => write!(f, "No certificates found in certificate file '{}'", path.display()),
-            // IdentityFileError{ certfile, keyfile, .. }      => write!(f, "Failed to parse '{}' and '{}' as a single Identity", certfile.display(), keyfile.display()),
-            // RootError{ cafile, .. }                         => write!(f, "Failed to parse '{}' as a root certificate", cafile.display()),
-            TempDirError { .. } => write!(f, "Failed to create temporary directory"),
-            DatasetDirError { name, .. } => write!(f, "Failed to create dataset directory for dataset '{name}'"),
-            ProxyCreateError { address, .. } => write!(f, "Failed to create new proxy to '{address}'"),
-            ClientCreateError { .. } => write!(f, "Failed to create new client"),
-            DownloadStreamError { address, .. } => write!(f, "Failed to get next chunk in download stream from '{address}'"),
-            TarCreateError { path, .. } => write!(f, "Failed to create tarball file '{}'", path.display()),
-            // TarOpenError{ path, .. }                => write!(f, "Failed to re-open tarball file '{}'", path.display()),
-            TarWriteError { path, .. } => write!(f, "Failed to write to tarball file '{}'", path.display()),
-            TarExtractError { .. } => write!(f, "Failed to extract downloaded archive"),
-
-            DatasetsError { .. } => write!(f, "Failed to get datasets folder"),
-            LocalDataIndexError { .. } => write!(f, "Failed to get local data index"),
-
-            AssetFileError { path, .. } => write!(f, "Failed to load given asset file '{}'", path.display()),
-            FileCanonicalizeError { path, .. } => write!(f, "Failed to resolve path '{}'", path.display()),
-            FileNotFoundError { path } => write!(f, "Referenced file '{}' not found (are you using the correct working directory?)", path.display()),
-            FileNotAFileError { path } => write!(f, "Referenced file '{}' is not a file", path.display()),
-            DatasetDirCreateError { .. } => write!(f, "Failed to create target dataset directory in the Brane data folder"),
-            DuplicateDatasetError { name } => write!(f, "A dataset with the name '{name}' already exists locally"),
-            DataCopyError { .. } => write!(f, "Failed to data directory"),
-            DataInfoWriteError { .. } => write!(f, "Failed to write DataInfo file"),
-
-            NoEqualsInKeyPair { raw } => write!(f, "Missing '=' in key/value pair '{raw}'"),
-            InstanceInfoError { .. } => write!(f, "Could not read active instance info file"),
-            ActiveInstanceReadError { .. } => write!(f, "Failed to read active instance link"),
-            InstancePathError { name, .. } => write!(f, "Could not get path of instance '{name}'"),
-            RemoteDataIndexError { address, .. } => write!(f, "Failed to fetch remote data index from '{address}'"),
-            DataSelectError { .. } => write!(f, "Failed to ask the user (you!) to select a download location"),
-            UnknownLocation { name } => write!(f, "Unknown location '{name}'"),
-
-            UnknownDataset { name } => write!(f, "Unknown dataset '{name}'"),
-            UnavailableDataset { name, locs } => write!(
-                f,
-                "Dataset '{}' is unavailable{}",
-                name,
-                if !locs.is_empty() {
-                    format!("; try {} instead", locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", "))
-                } else {
-                    String::new()
-                }
-            ),
-
-            // DatasetDirError{ .. }   => write!(f, "Failed to get to-be-removed dataset directory: {}", err),
-            ConfirmationError { .. } => write!(f, "Failed to ask the user (you) for confirmation before removing a dataset"),
-            RemoveError { path, .. } => write!(f, "Failed to remove dataset directory '{}'", path.display()),
-            WorkflowSerializeError { context, .. } => write!(f, "Could not serialize workflow when: {context}"),
-        }
-    }
-}
-impl Error for DataError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use DataError::*;
-        match self {
-            RequestError { err, .. } => Some(err),
-            RequestFailure { .. } => None,
-            ResponseTextError { err, .. } => Some(err),
-            // KeypairLoadError{ .. } => None,
-            // StoreLoadError{ .. } => None,
-            FileReadError { err, .. } => Some(err),
-            CertsDirError { .. } => None,
-            IdentityFileError { err, .. } => Some(err),
-            CertificateError { err, .. } => Some(err),
-            DirNotADirError { .. } => None,
-            DirRemoveError { err, .. } => Some(err),
-            DirCreateError { err, .. } => Some(err),
-            // EmptyCertFile{ .. } => None,
-            // IdentityFileError{ err, .. } => Some(err),
-            // RootError{ err, .. } => Some(err),
-            TempDirError { .. } => None,
-            DatasetDirError { err, .. } => Some(err),
-            ProxyCreateError { err, .. } => Some(err),
-            ClientCreateError { .. } => None,
-            DownloadStreamError { err, .. } => Some(err),
-            TarCreateError { err, .. } => Some(err),
-            // TarOpenError{ err, .. } => Some(err),
-            TarWriteError { err, .. } => Some(err),
-            // TarExtractError{ err, .. } => Some(err),
-            TarExtractError { err, .. } => Some(err),
-
-            DatasetsError { .. } => None,
-            LocalDataIndexError { .. } => None,
-
-            AssetFileError { err, .. } => Some(err),
-            FileCanonicalizeError { err, .. } => Some(err),
-            FileNotFoundError { .. } => None,
-            FileNotAFileError { .. } => None,
-            DatasetDirCreateError { .. } => None,
-            DuplicateDatasetError { .. } => None,
-            DataCopyError { .. } => None,
-            DataInfoWriteError { .. } => None,
-
-            NoEqualsInKeyPair { .. } => None,
-            InstanceInfoError { .. } => None,
-            ActiveInstanceReadError { .. } => None,
-            InstancePathError { err, .. } => Some(err),
-            RemoteDataIndexError { err, .. } => Some(err),
-            DataSelectError { .. } => None,
-            UnknownLocation { .. } => None,
-
-            UnknownDataset { .. } => None,
-            UnavailableDataset { .. } => None,
-
-            // DatasetDirError{ .. } => None,
-            ConfirmationError { .. } => None,
-            RemoveError { err, .. } => Some(err),
-            WorkflowSerializeError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors during the import subcommand
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ImportError {
     /// Error for when we could not create a temporary directory
-    TempDirError { err: std::io::Error },
+    #[error("Could not create temporary repository directory")]
+    TempDirError { source: std::io::Error },
     /// Could not resolve the path to the temporary repository directory
-    TempDirCanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Could not resolve temporary directory path '{}'", path.display())]
+    TempDirCanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Error for when we failed to download a repository
-    RepoCloneError { repo: String, target: PathBuf, err: brane_shr::fs::Error },
-
+    #[error("Could not clone repository at '{}' to directory '{}'", repo, target.display())]
+    RepoCloneError { repo: String, target: PathBuf, source: brane_shr::fs::Error },
     /// Error for when a path supposed to refer inside the repository escaped out of it
+    #[error("Path '{}' points outside of repository folder", path.display())]
     RepoEscapeError { path: PathBuf },
 }
-impl Display for ImportError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ImportError::*;
-        match self {
-            TempDirError { .. } => write!(f, "Could not create temporary repository directory"),
-            TempDirCanonicalizeError { path, .. } => {
-                write!(f, "Could not resolve temporary directory path '{}'", path.display())
-            },
-            RepoCloneError { repo, target, .. } => {
-                write!(f, "Could not clone repository at '{}' to directory '{}'", repo, target.display())
-            },
-
-            RepoEscapeError { path } => write!(f, "Path '{}' points outside of repository folder", path.display()),
-        }
-    }
-}
-impl Error for ImportError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use ImportError::*;
-        match self {
-            TempDirError { err, .. } => Some(err),
-            TempDirCanonicalizeError { err, .. } => Some(err),
-            RepoCloneError { err, .. } => Some(err),
-
-            RepoEscapeError { .. } => None,
-        }
-    }
-}
-
-
 
 /// Collects errors  during the identity-related subcommands (login, logout).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum InstanceError {
     /// Failed to get the directory of a specific instance.
-    InstanceDirError { err: UtilError },
+    #[error("Failed to get directory for instance")]
+    InstanceDirError { source: UtilError },
     /// Failed to open a file to load an InstanceInfo.
-    InstanceInfoOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open instance info file '{}'", path.display())]
+    InstanceInfoOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read a file to load an InstanceInfo.
-    InstanceInfoReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read instance info file '{}'", path.display())]
+    InstanceInfoReadError { path: PathBuf, source: std::io::Error },
     /// Failed to parse the file to load an InstanceInfo.
-    InstanceInfoParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse instance info file '{}' as valid YAML", path.display())]
+    InstanceInfoParseError { path: PathBuf, source: serde_yaml::Error },
     /// Failed to (re-)serialize an InstanceInfo.
-    InstanceInfoSerializeError { err: serde_yaml::Error },
+    #[error("Failed to serialize instance info struct")]
+    InstanceInfoSerializeError { source: serde_yaml::Error },
     /// Failed to create a new file to write an InstanceInfo to.
-    InstanceInfoCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create new info instance file '{}'", path.display())]
+    InstanceInfoCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write an InstanceInfo the given file.
-    InstanceInfoWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to instance info file '{}'", path.display())]
+    InstanceInfoWriteError { path: PathBuf, source: std::io::Error },
 
     /// The given instance name is invalid.
+    #[error("Instance name '{raw}' contains illegal character '{illegal_char}' (use '--name' to override it with a custom one)")]
     IllegalInstanceName { raw: String, illegal_char: char },
     /// Failed to parse an address from the hostname (and a little modification).
-    AddressParseError { err: specifications::address::AddressError },
+    #[error("Failed to convert hostname to a valid address")]
+    AddressParseError { source: specifications::address::AddressError },
     /// Failed to send a request to the remote instance.
-    RequestError { address: String, err: reqwest::Error },
+    #[error(
+        "Failed to send request to the instance API at '{address}' (if this is something on your end, you may skip this check by providing \
+         '--unchecked')"
+    )]
+    RequestError { address: String, source: reqwest::Error },
     /// The remote instance was not alive (at least, API/health was not)
+    #[error("Remote instance at '{}' is not alive (returned {} ({}){})", address, code, code.canonical_reason().unwrap_or("???"), if let Some(err) = err { format!("\n\nResponse:\n{}\n", BlockFormatter::new(err)) } else { String::new() })]
     InstanceNotAliveError { address: String, code: StatusCode, err: Option<String> },
 
     /// Failed to ask the user for confirmation.
-    ConfirmationError { err: dialoguer::Error },
+    #[error("Failed to ask the user (you!) for confirmation (if you are sure, you can skip this step by using '--force')")]
+    ConfirmationError { source: dialoguer::Error },
 
     /// Failed to get the instances directory.
-    InstancesDirError { err: UtilError },
+    #[error("Failed to get the instances directory")]
+    InstancesDirError { source: UtilError },
     /// Failed to read the instances directory.
-    InstancesDirReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read instances directory '{}'", path.display())]
+    InstancesDirReadError { path: PathBuf, source: std::io::Error },
     /// Failed to read an entry in the instances directory.
-    InstancesDirEntryReadError { path: PathBuf, entry: usize, err: std::io::Error },
+    #[error("Failed to read instances directory '{}' entry {}", path.display(), entry)]
+    InstancesDirEntryReadError { path: PathBuf, entry: usize, source: std::io::Error },
     /// Failed to get the actual directory behind the active instance link.
-    ActiveInstanceTargetError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to get target of active instance link '{}'", path.display())]
+    ActiveInstanceTargetError { path: PathBuf, source: std::io::Error },
 
     /// The given instance is unknown to us.
+    #[error("Unknown instance '{name}'")]
     UnknownInstance { name: String },
     /// The given instance exists but is not a directory.
+    #[error("Instance directory '{}' exists but is not a directory", path.display())]
     InstanceNotADirError { path: PathBuf },
     /// Failed to get the path of the active instance link.
-    ActiveInstancePathError { err: UtilError },
+    #[error("Failed to get active instance link path")]
+    ActiveInstancePathError { source: UtilError },
     /// The active instance file exists but is not a softlink.
+    #[error("Active instance link '{}' exists but is not a file", path.display())]
     ActiveInstanceNotAFileError { path: PathBuf },
     /// Failed to read the active instance link file.
-    ActiveInstanceReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read active instance link '{}'", path.display())]
+    ActiveInstanceReadError { path: PathBuf, source: std::io::Error },
     /// Failed to remove an already existing active instance link.
-    ActiveInstanceRemoveError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to remove existing active instance link '{}'", path.display())]
+    ActiveInstanceRemoveError { path: PathBuf, source: std::io::Error },
     /// Failed to create a new active instance link.
-    ActiveInstanceCreateError { path: PathBuf, target: String, err: std::io::Error },
+    #[error("Failed to create active instance link '{}' to '{}'", path.display(), target)]
+    ActiveInstanceCreateError { path: PathBuf, target: String, source: std::io::Error },
 
     /// No instance is active
+    #[error("No active instance is set (run 'brane instance select' first)")]
     NoActiveInstance,
 }
-impl Display for InstanceError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use InstanceError::*;
-        match self {
-            InstanceDirError { .. } => write!(f, "Failed to get directory for instance"),
-            InstanceInfoOpenError { path, .. } => write!(f, "Failed to open instance info file '{}'", path.display()),
-            InstanceInfoReadError { path, .. } => write!(f, "Failed to read instance info file '{}'", path.display()),
-            InstanceInfoParseError { path, .. } => write!(f, "Failed to parse instance info file '{}' as valid YAML", path.display()),
-            InstanceInfoSerializeError { .. } => write!(f, "Failed to serialize instance info struct"),
-            InstanceInfoCreateError { path, .. } => write!(f, "Failed to create new info instance file '{}'", path.display()),
-            InstanceInfoWriteError { path, .. } => write!(f, "Failed to write to instance info file '{}'", path.display()),
-
-            IllegalInstanceName { raw, illegal_char } => {
-                write!(f, "Instance name '{raw}' contains illegal character '{illegal_char}' (use '--name' to override it with a custom one)")
-            },
-            AddressParseError { .. } => write!(f, "Failed to convert hostname to a valid address"),
-            RequestError { address, .. } => write!(
-                f,
-                "Failed to send request to the instance API at '{address}' (if this is something on your end, you may skip this check by providing \
-                 '--unchecked')"
-            ),
-            InstanceNotAliveError { address, code, err } => write!(
-                f,
-                "Remote instance at '{}' is not alive (returned {} ({}){})",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(err) = err { format!("\n\nResponse:\n{}\n", BlockFormatter::new(err)) } else { String::new() }
-            ),
-
-            ConfirmationError { .. } => {
-                write!(f, "Failed to ask the user (you!) for confirmation (if you are sure, you can skip this step by using '--force')")
-            },
-
-            InstancesDirError { .. } => write!(f, "Failed to get the instances directory"),
-            InstancesDirReadError { path, .. } => write!(f, "Failed to read instances directory '{}'", path.display()),
-            InstancesDirEntryReadError { path, entry, .. } => {
-                write!(f, "Failed to read instances directory '{}' entry {}", path.display(), entry)
-            },
-            ActiveInstanceTargetError { path, .. } => write!(f, "Failed to get target of active instance link '{}'", path.display()),
-
-            UnknownInstance { name } => write!(f, "Unknown instance '{name}'"),
-            InstanceNotADirError { path } => write!(f, "Instance directory '{}' exists but is not a directory", path.display()),
-            ActiveInstancePathError { .. } => write!(f, "Failed to get active instance link path"),
-            ActiveInstanceNotAFileError { path } => write!(f, "Active instance link '{}' exists but is not a file", path.display()),
-            ActiveInstanceReadError { path, .. } => write!(f, "Failed to read active instance link '{}'", path.display()),
-            ActiveInstanceRemoveError { path, .. } => write!(f, "Failed to remove existing active instance link '{}'", path.display()),
-            ActiveInstanceCreateError { path, target, .. } => {
-                write!(f, "Failed to create active instance link '{}' to '{}'", path.display(), target)
-            },
-
-            NoActiveInstance => write!(f, "No active instance is set (run 'brane instance select' first)"),
-        }
-    }
-}
-impl Error for InstanceError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use InstanceError::*;
-        match self {
-            InstanceDirError { err, .. } => Some(err),
-            InstanceInfoOpenError { err, .. } => Some(err),
-            InstanceInfoReadError { err, .. } => Some(err),
-            InstanceInfoParseError { err, .. } => Some(err),
-            InstanceInfoSerializeError { err, .. } => Some(err),
-            InstanceInfoCreateError { err, .. } => Some(err),
-            InstanceInfoWriteError { err, .. } => Some(err),
-
-            IllegalInstanceName { .. } => None,
-            AddressParseError { err, .. } => Some(err),
-            RequestError { err, .. } => Some(err),
-            InstanceNotAliveError { .. } => None,
-
-            ConfirmationError { err, .. } => Some(err),
-
-            InstancesDirError { err, .. } => Some(err),
-            InstancesDirReadError { err, .. } => Some(err),
-            InstancesDirEntryReadError { err, .. } => Some(err),
-            ActiveInstanceTargetError { err, .. } => Some(err),
-
-            UnknownInstance { .. } => None,
-            InstanceNotADirError { .. } => None,
-            ActiveInstancePathError { err, .. } => Some(err),
-            ActiveInstanceNotAFileError { .. } => None,
-            ActiveInstanceReadError { err, .. } => Some(err),
-            ActiveInstanceRemoveError { err, .. } => Some(err),
-            ActiveInstanceCreateError { err, .. } => Some(err),
-
-            NoActiveInstance => None,
-        }
-    }
-}
-
-
 
 /// Lists the errors that can occur when trying to do stuff with packages
 ///
 /// Note: `Image` is boxed to avoid the error enum growing too large (see `clippy::reslt_large_err`).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PackageError {
     /// Something went wrong while calling utilities
-    UtilError { err: UtilError },
+    #[error(transparent)]
+    UtilError { source: UtilError },
     /// Something went wrong when fetching an index.
-    IndexError { err: brane_tsk::local::Error },
+    #[error("Failed to fetch a local package index")]
+    IndexError { source: brane_tsk::local::Error },
 
     /// Failed to resolve a specific package/version pair
-    PackageVersionError { name: String, version: Version, err: UtilError },
+    #[error("Package '{name}' does not exist or has no version {version}")]
+    PackageVersionError { name: String, version: Version, source: UtilError },
     /// Failed to resolve a specific package
-    PackageError { name: String, err: UtilError },
+    #[error("Package '{name}' does not exist")]
+    PackageError { name: String, source: UtilError },
     /// Failed to ask for the user's consent
-    ConsentError { err: dialoguer::Error },
+    #[error("Failed to ask for your consent")]
+    ConsentError { source: dialoguer::Error },
     /// Failed to remove a package directory
-    PackageRemoveError { name: String, version: Version, dir: PathBuf, err: std::io::Error },
+    #[error("Failed to remove package '{}' (version {}) at '{}'", name, version, dir.display())]
+    PackageRemoveError { name: String, version: Version, dir: PathBuf, source: std::io::Error },
     /// Failed to get the versions of a package
-    VersionsError { name: String, dir: PathBuf, err: std::io::Error },
+    #[error("Failed to get versions of package '{}' (at '{}')", name, dir.display())]
+    VersionsError { name: String, dir: PathBuf, source: std::io::Error },
     /// Failed to parse the version of a package
-    VersionParseError { name: String, raw: String, err: specifications::version::ParseError },
+    #[error("Could not parse '{raw}' as a version for package '{name}'")]
+    VersionParseError { name: String, raw: String, source: specifications::version::ParseError },
     /// Failed to load the PackageInfo of the given package
-    PackageInfoError { path: PathBuf, err: specifications::package::PackageInfoError },
+    #[error("Could not load package info file '{}'", path.display())]
+    PackageInfoError { path: PathBuf, source: specifications::package::PackageInfoError },
     /// The given PackageInfo has no digest set
+    #[error("Package info file '{}' has no digest set", path.display())]
     PackageInfoNoDigest { path: PathBuf },
     /// Could not remove the given image from the Docker daemon
-    DockerRemoveError { image: Box<Image>, err: brane_tsk::errors::DockerError },
+    #[error("Failed to remove image '{}' from the local Docker daemon", image.digest().unwrap_or("<no digest given>"))]
+    DockerRemoveError { image: Box<Image>, source: brane_tsk::errors::DockerError },
 }
-impl std::fmt::Display for PackageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use self::PackageError::*;
-        match self {
-            UtilError { err } => write!(f, "{}", err.trace()),
-            IndexError { .. } => write!(f, "Failed to fetch a local package index"),
-
-            PackageVersionError { name, version, .. } => write!(f, "Package '{name}' does not exist or has no version {version}"),
-            PackageError { name, .. } => write!(f, "Package '{name}' does not exist"),
-            ConsentError { .. } => write!(f, "Failed to ask for your consent"),
-            PackageRemoveError { name, version, dir, .. } => {
-                write!(f, "Failed to remove package '{}' (version {}) at '{}'", name, version, dir.display())
-            },
-            VersionsError { name, dir, .. } => write!(f, "Failed to get versions of package '{}' (at '{}')", name, dir.display()),
-            VersionParseError { name, raw, .. } => write!(f, "Could not parse '{raw}' as a version for package '{name}'"),
-            PackageInfoError { path, .. } => write!(f, "Could not load package info file '{}'", path.display()),
-            PackageInfoNoDigest { path } => write!(f, "Package info file '{}' has no digest set", path.display()),
-            DockerRemoveError { image, .. } => {
-                write!(f, "Failed to remove image '{}' from the local Docker daemon", image.digest().unwrap_or("<no digest given>"))
-            },
-        }
-    }
-}
-impl std::error::Error for PackageError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use self::PackageError::*;
-        match self {
-            UtilError { .. } => None,
-            IndexError { err } => Some(err),
-
-            PackageVersionError { err, .. } => Some(err),
-            PackageError { err, .. } => Some(err),
-            ConsentError { err } => Some(err),
-            PackageRemoveError { err, .. } => Some(err),
-            VersionsError { err, .. } => Some(err),
-            VersionParseError { err, .. } => Some(err),
-            PackageInfoError { err, .. } => Some(err),
-            PackageInfoNoDigest { .. } => None,
-            DockerRemoveError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors during the registry subcommands
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RegistryError {
     /// Wrapper error indeed.
-    InstanceInfoError { err: InstanceError },
+    #[error(transparent)]
+    InstanceInfoError { source: InstanceError },
 
     /// Failed to successfully send the package pull request
-    PullRequestError { url: String, err: reqwest::Error },
+    #[error("Could not send the request to pull pacakge to '{url}'")]
+    PullRequestError { url: String, source: reqwest::Error },
     /// The request was sent successfully, but the server replied with a non-200 access code
+    #[error("Request to pull package from '{}' was met with status code {} ({})", url, status.as_u16(), status.canonical_reason().unwrap_or("???"))]
     PullRequestFailure { url: String, status: reqwest::StatusCode },
     /// The request did not have a content length specified
+    #[error("Response from '{url}' did not have 'Content-Length' header set")]
     MissingContentLength { url: String },
     /// Failed to convert the content length from raw bytes to string
-    ContentLengthStrError { url: String, err: reqwest::header::ToStrError },
+    #[error("Could not convert content length received from '{url}' to string")]
+    ContentLengthStrError { url: String, source: reqwest::header::ToStrError },
     /// Failed to parse the content length as a number
-    ContentLengthParseError { url: String, raw: String, err: std::num::ParseIntError },
+    #[error("Could not parse '{raw}' as a number (the content-length received from '{url}')")]
+    ContentLengthParseError { url: String, raw: String, source: std::num::ParseIntError },
     /// Failed to download the actual package
-    PackageDownloadError { url: String, err: reqwest::Error },
+    #[error("Could not download package from '{url}'")]
+    PackageDownloadError { url: String, source: reqwest::Error },
     /// Failed to write the downloaded package to the given file
-    PackageWriteError { url: String, path: PathBuf, err: std::io::Error },
+    #[error("Could not write package downloaded from '{}' to '{}'", url, path.display())]
+    PackageWriteError { url: String, path: PathBuf, source: std::io::Error },
     /// Failed to create the package directory
-    PackageDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create package directory '{}'", path.display())]
+    PackageDirCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to copy the downloaded package over
-    PackageCopyError { source: PathBuf, target: PathBuf, err: std::io::Error },
+    #[error("Could not copy package from '{}' to '{}'", original.display(), target.display())]
+    PackageCopyError { original: PathBuf, target: PathBuf, source: std::io::Error },
     /// Failed to send GraphQL request for package info
-    GraphQLRequestError { url: String, err: reqwest::Error },
+    #[error("Could not send a GraphQL request to '{url}'")]
+    GraphQLRequestError { url: String, source: reqwest::Error },
     /// Failed to receive GraphQL response with package info
-    GraphQLResponseError { url: String, err: reqwest::Error },
+    #[error("Could not get the GraphQL respones from '{url}'")]
+    GraphQLResponseError { url: String, source: reqwest::Error },
     /// Could not parse the kind as a proper PackageInfo kind
-    KindParseError { url: String, raw: String, err: specifications::package::PackageKindError },
+    #[error("Could not parse '{raw}' (received from '{url}') as package kind")]
+    KindParseError { url: String, raw: String, source: specifications::package::PackageKindError },
     /// Could not parse the version as a proper PackageInfo version
-    VersionParseError { url: String, raw: String, err: specifications::version::ParseError },
+    #[error("Could not parse '{raw}' (received from '{url}') as package version")]
+    VersionParseError { url: String, raw: String, source: specifications::version::ParseError },
     /// Could not parse the list of requirements of the package.
-    RequirementParseError { url: String, raw: String, err: serde_json::Error },
+    #[error("Could not parse '{raw}' (received from '{url}') as package requirement")]
+    RequirementParseError { url: String, raw: String, source: serde_json::Error },
     /// Could not parse the functions as proper PackageInfo functions
-    FunctionsParseError { url: String, raw: String, err: serde_json::Error },
+    #[error("Could not parse '{raw}' (received from '{url}') as package functions")]
+    FunctionsParseError { url: String, raw: String, source: serde_json::Error },
     /// Could not parse the types as proper PackageInfo types
-    TypesParseError { url: String, raw: String, err: serde_json::Error },
+    #[error("Could not parse '{raw}' (received from '{url}') as package types")]
+    TypesParseError { url: String, raw: String, source: serde_json::Error },
     /// Could not create a file for the PackageInfo
-    PackageInfoCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create PackageInfo file '{}'", path.display())]
+    PackageInfoCreateError { path: PathBuf, source: std::io::Error },
     /// Could not write the PackageInfo
-    PackageInfoWriteError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Could not write to PackageInfo file '{}'", path.display())]
+    PackageInfoWriteError { path: PathBuf, source: serde_yaml::Error },
     /// Failed to retrieve the PackageInfo
+    #[error("Server '{url}' responded with empty response (is your name/version correct?)")]
     NoPackageInfo { url: String },
 
     /// Failed to resolve the packages directory
-    PackagesDirError { err: UtilError },
+    #[error("Could not resolve the packages directory")]
+    PackagesDirError { source: UtilError },
     /// Failed to get all versions for the given package
-    VersionsError { name: String, err: brane_tsk::local::Error },
+    #[error("Could not get version list for package '{name}'")]
+    VersionsError { name: String, source: brane_tsk::local::Error },
     /// Failed to resolve the directory of a specific package
-    PackageDirError { name: String, version: Version, err: UtilError },
+    #[error("Could not resolve package directory of package '{name}' (version {version})")]
+    PackageDirError { name: String, version: Version, source: UtilError },
     /// Could not create a new temporary file
-    TempFileError { err: std::io::Error },
+    #[error("Could not create a new temporary file")]
+    TempFileError { source: std::io::Error },
     /// Could not compress the package file
-    CompressionError { name: String, version: Version, path: PathBuf, err: std::io::Error },
+    #[error("Could not compress package '{}' (version {}) to '{}'", name, version, path.display())]
+    CompressionError { name: String, version: Version, path: PathBuf, source: std::io::Error },
     /// Failed to re-open the compressed package file
-    PackageArchiveOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Could not re-open compressed package archive '{}'", path.display())]
+    PackageArchiveOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to upload the compressed file to the instance
-    UploadError { path: PathBuf, endpoint: String, err: reqwest::Error },
+    #[error("Could not upload compressed package archive '{}' to '{}'", path.display(), endpoint)]
+    UploadError { path: PathBuf, endpoint: String, source: reqwest::Error },
 }
-impl Display for RegistryError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use RegistryError::*;
-        match self {
-            InstanceInfoError { err } => write!(f, "{err}"),
-
-            PullRequestError { url, err } => write!(f, "Could not send the request to pull pacakge to '{url}': {err}"),
-            PullRequestFailure { url, status } => write!(
-                f,
-                "Request to pull package from '{}' was met with status code {} ({})",
-                url,
-                status.as_u16(),
-                status.canonical_reason().unwrap_or("???")
-            ),
-            MissingContentLength { url } => write!(f, "Response from '{url}' did not have 'Content-Length' header set"),
-            ContentLengthStrError { url, err } => write!(f, "Could not convert content length received from '{url}' to string: {err}"),
-            ContentLengthParseError { url, raw, err } => {
-                write!(f, "Could not parse '{raw}' as a number (the content-length received from '{url}'): {err}")
-            },
-            PackageDownloadError { url, err } => write!(f, "Could not download package from '{url}': {err}"),
-            PackageWriteError { url, path, err } => write!(f, "Could not write package downloaded from '{}' to '{}': {}", url, path.display(), err),
-            PackageDirCreateError { path, err } => write!(f, "Could not create package directory '{}': {}", path.display(), err),
-            PackageCopyError { source, target, err } => {
-                write!(f, "Could not copy package from '{}' to '{}': {}", source.display(), target.display(), err)
-            },
-            GraphQLRequestError { url, err } => write!(f, "Could not send a GraphQL request to '{url}': {err}"),
-            GraphQLResponseError { url, err } => write!(f, "Could not get the GraphQL respones from '{url}': {err}"),
-            KindParseError { url, raw, err } => write!(f, "Could not parse '{raw}' (received from '{url}') as package kind: {err}"),
-            VersionParseError { url, raw, err } => write!(f, "Could not parse '{raw}' (received from '{url}') as package version: {err}"),
-            RequirementParseError { url, raw, err } => write!(f, "Could not parse '{raw}' (received from '{url}') as package requirement: {err}"),
-            FunctionsParseError { url, raw, err } => write!(f, "Could not parse '{raw}' (received from '{url}') as package functions: {err}"),
-            TypesParseError { url, raw, err } => write!(f, "Could not parse '{raw}' (received from '{url}') as package types: {err}"),
-            PackageInfoCreateError { path, err } => write!(f, "Could not create PackageInfo file '{}': {}", path.display(), err),
-            PackageInfoWriteError { path, err } => write!(f, "Could not write to PackageInfo file '{}': {}", path.display(), err),
-            NoPackageInfo { url } => write!(f, "Server '{url}' responded with empty response (is your name/version correct?)"),
-
-            PackagesDirError { err } => write!(f, "Could not resolve the packages directory: {err}"),
-            VersionsError { name, err } => write!(f, "Could not get version list for package '{name}': {err}"),
-            PackageDirError { name, version, err } => write!(f, "Could not resolve package directory of package '{name}' (version {version}): {err}"),
-            TempFileError { err } => write!(f, "Could not create a new temporary file: {err}"),
-            CompressionError { name, version, path, err } => {
-                write!(f, "Could not compress package '{}' (version {}) to '{}': {}", name, version, path.display(), err)
-            },
-            PackageArchiveOpenError { path, err } => write!(f, "Could not re-open compressed package archive '{}': {}", path.display(), err),
-            UploadError { path, endpoint, err } => {
-                write!(f, "Could not upload compressed package archive '{}' to '{}': {}", path.display(), endpoint, err)
-            },
-        }
-    }
-}
-impl Error for RegistryError {}
-
-
 
 /// Collects errors during the repl subcommand
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReplError {
     /// Could not create the config directory
-    ConfigDirCreateError { err: UtilError },
+    #[error("Could not create the configuration directory for the REPL history")]
+    ConfigDirCreateError { source: UtilError },
     /// Could not get the location of the REPL history file
-    HistoryFileError { err: UtilError },
+    #[error("Could not get REPL history file location")]
+    HistoryFileError { source: UtilError },
     /// Failed to create the new rustyline editor.
-    EditorCreateError { err: rustyline::error::ReadlineError },
+    #[error("Failed to create new rustyline editor")]
+    EditorCreateError { source: rustyline::error::ReadlineError },
     /// Failed to load the login file.
-    InstanceInfoError { err: InstanceError },
+    #[error("Failed to load instance info file")]
+    InstanceInfoError { source: InstanceError },
 
     /// Failed to initialize one of the states.
-    InitializeError { what: &'static str, err: RunError },
+    #[error("Failed to initialize {what} and associated structures")]
+    InitializeError { what: &'static str, source: RunError },
     /// Failed to run one of the VMs/clients.
-    RunError { what: &'static str, err: RunError },
+    #[error("Failed to execute workflow on {what}")]
+    RunError { what: &'static str, source: RunError },
     /// Failed to process the VM result.
-    ProcessError { what: &'static str, err: RunError },
+    #[error("Failed to process {what} workflow results")]
+    ProcessError { what: &'static str, source: RunError },
 }
-impl Display for ReplError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ReplError::*;
-        match self {
-            ConfigDirCreateError { .. } => write!(f, "Could not create the configuration directory for the REPL history"),
-            HistoryFileError { .. } => write!(f, "Could not get REPL history file location"),
-            EditorCreateError { .. } => write!(f, "Failed to create new rustyline editor"),
-            InstanceInfoError { .. } => write!(f, "Failed to load instance info file"),
-
-            InitializeError { what, .. } => write!(f, "Failed to initialize {what} and associated structures"),
-            RunError { what, .. } => write!(f, "Failed to execute workflow on {what}"),
-            ProcessError { what, .. } => write!(f, "Failed to process {what} workflow results"),
-        }
-    }
-}
-impl Error for ReplError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use ReplError::*;
-        match self {
-            ConfigDirCreateError { err } => Some(err),
-            HistoryFileError { err } => Some(err),
-            EditorCreateError { err } => Some(err),
-            InstanceInfoError { err } => Some(err),
-
-            InitializeError { err, .. } => Some(err),
-            RunError { err, .. } => Some(err),
-            ProcessError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors during the run subcommand.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RunError {
     /// Failed to write to the given formatter.
-    WriteError { err: std::io::Error },
+    #[error("Failed to write to the given formatter")]
+    WriteError {
+        #[from]
+        source: std::io::Error,
+    },
 
     /// Failed to create the local package index.
-    LocalPackageIndexError { err: brane_tsk::local::Error },
+    #[error("Failed to fetch local package index")]
+    LocalPackageIndexError { source: brane_tsk::local::Error },
     /// Failed to create the local data index.
-    LocalDataIndexError { err: brane_tsk::local::Error },
+    #[error("Failed to fetch local data index")]
+    LocalDataIndexError { source: brane_tsk::local::Error },
     /// Failed to get the packages directory.
-    PackagesDirError { err: UtilError },
+    #[error("Failed to get packages directory")]
+    PackagesDirError { source: UtilError },
     /// Failed to get the datasets directory.
-    DatasetsDirError { err: UtilError },
+    #[error("Failed to get datasets directory")]
+    DatasetsDirError { source: UtilError },
     /// Failed to create a temporary intermediate results directory.
-    ResultsDirCreateError { err: std::io::Error },
+    #[error("Failed to create new temporary directory as an intermediate result directory")]
+    ResultsDirCreateError { source: std::io::Error },
 
     /// Failed to fetch the login file.
-    InstanceInfoError { err: InstanceError },
+    #[error(transparent)]
+    InstanceInfoError { source: InstanceError },
     /// Failed to get the path of the active instance.
-    ActiveInstanceReadError { err: InstanceError },
+    #[error("Failed to read active instance link")]
+    ActiveInstanceReadError { source: InstanceError },
     /// Failed to get the active instance.
-    InstancePathError { name: String, err: InstanceError },
+    #[error("Could not get path of instance '{name}'")]
+    InstancePathError { name: String, source: InstanceError },
     /// Failed to create the remote package index.
-    RemotePackageIndexError { address: String, err: brane_tsk::errors::ApiError },
+    #[error("Failed to fetch remote package index from '{address}'")]
+    RemotePackageIndexError { address: String, source: brane_tsk::errors::ApiError },
     /// Failed to create the remote data index.
-    RemoteDataIndexError { address: String, err: brane_tsk::errors::ApiError },
+    #[error("Failed to fetch remote data index from '{address}'")]
+    RemoteDataIndexError { address: String, source: brane_tsk::errors::ApiError },
     /// Failed to pull the delegate map from the remote delegate index(ish - `brane-api`)
-    RemoteDelegatesError { address: String, err: DelegatesError },
+    #[error("Failed to fetch delegates map from '{address}'")]
+    RemoteDelegatesError { address: String, source: DelegatesError },
     /// Could not connect to the given address
-    ClientConnectError { address: String, err: specifications::driving::Error },
+    #[error("Could not connect to remote Brane instance '{address}'")]
+    ClientConnectError { address: String, source: specifications::driving::Error },
     /// Failed to parse the AppId send by the remote driver.
     ///
     /// Note: `err` is boxed to avoid this error enum growing too large.
-    AppIdError { address: String, raw: String, err: Box<brane_tsk::errors::IdError> },
+    #[error("Could not parse '{raw}' send by remote '{address}' as an application ID")]
+    AppIdError { address: String, raw: String, source: Box<brane_tsk::errors::IdError> },
     /// Could not create a new session on the given address
-    SessionCreateError { address: String, err: tonic::Status },
+    #[error("Could not create new session with remote Brane instance '{address}': remote returned status")]
+    SessionCreateError { address: String, source: tonic::Status },
 
     /// An error occurred while compile the given snippet. It will already have been printed to stdout.
+    #[error("Compilation of workflow failed (see output above)")]
     CompileError(brane_ast::errors::CompileError),
     /// Failed to serialize the compiled workflow.
-    WorkflowSerializeError { err: serde_json::Error },
+    #[error("Failed to serialize the compiled workflow")]
+    WorkflowSerializeError { source: serde_json::Error },
     /// Requesting a command failed
-    CommandRequestError { address: String, err: tonic::Status },
+    #[error("Could not run command on remote Brane instance '{address}': request failed: remote returned status")]
+    CommandRequestError { address: String, source: tonic::Status },
     /// Failed to parse the value returned by the remote driver.
-    ValueParseError { address: String, raw: String, err: serde_json::Error },
+    #[error("Could not parse '{raw}' sent by remote '{address}' as a value")]
+    ValueParseError { address: String, raw: String, source: serde_json::Error },
     /// The workflow was denied by some checker.
-    ExecDenied { err: Box<dyn Error> },
+    #[error("Workflow was denied")]
+    ExecDenied { source: Box<dyn Error> },
     /// Failed to run the workflow
-    ExecError { err: Box<dyn Error> },
+    #[error("Failed to run workflow")]
+    ExecError { source: Box<dyn Error> },
 
     /// The returned dataset was unknown.
+    #[error("Unknown dataset '{name}'")]
     UnknownDataset { name: String },
     /// The returend dataset was known but not available locally.
+    #[error("Unavailable dataset '{}'{}", name, if !locs.is_empty() { format!("; it is available at {}", PrettyListFormatter::new(locs.iter().map(|l| format!("'{l}'")), "or")) } else { String::new() })]
     UnavailableDataset { name: String, locs: Vec<String> },
     /// Failed to download remote dataset.
-    DataDownloadError { err: DataError },
+    #[error("Failed to download remote dataset")]
+    DataDownloadError { source: DataError },
 
     /// Failed to read the source from stdin
-    StdinReadError { err: std::io::Error },
+    #[error("Failed to read source from stdin")]
+    StdinReadError { source: std::io::Error },
     /// Failed to read the source from a given file
-    FileReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read source from file '{}'", path.display())]
+    FileReadError { path: PathBuf, source: std::io::Error },
     /// Failed to load the login file.
-    LoginFileError { err: UtilError },
-    // /// Failed to compile the given file (the reasons have already been printed to stderr).
-    // CompileError{ path: PathBuf, errs: Vec<brane_ast::Error> },
+    #[error(transparent)]
+    LoginFileError { source: UtilError },
 }
-impl Display for RunError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use RunError::*;
-        match self {
-            WriteError { .. } => write!(f, "Failed to write to the given formatter"),
-
-            LocalPackageIndexError { .. } => write!(f, "Failed to fetch local package index"),
-            LocalDataIndexError { .. } => write!(f, "Failed to fetch local data index"),
-            PackagesDirError { .. } => write!(f, "Failed to get packages directory"),
-            DatasetsDirError { .. } => write!(f, "Failed to get datasets directory"),
-            ResultsDirCreateError { .. } => write!(f, "Failed to create new temporary directory as an intermediate result directory"),
-
-            InstanceInfoError { err } => write!(f, "{err}"),
-            ActiveInstanceReadError { .. } => write!(f, "Failed to read active instance link"),
-            InstancePathError { name, .. } => write!(f, "Could not get path of instance '{name}'"),
-            RemotePackageIndexError { address, .. } => write!(f, "Failed to fetch remote package index from '{address}'"),
-            RemoteDataIndexError { address, .. } => write!(f, "Failed to fetch remote data index from '{address}'"),
-            RemoteDelegatesError { address, .. } => write!(f, "Failed to fetch delegates map from '{address}'"),
-            ClientConnectError { address, .. } => write!(f, "Could not connect to remote Brane instance '{address}'"),
-            AppIdError { address, raw, .. } => write!(f, "Could not parse '{raw}' send by remote '{address}' as an application ID"),
-            SessionCreateError { address, .. } => {
-                write!(f, "Could not create new session with remote Brane instance '{address}': remote returned status")
-            },
-
-            CompileError { .. } => write!(f, "Compilation of workflow failed (see output above)"),
-            WorkflowSerializeError { .. } => write!(f, "Failed to serialize the compiled workflow"),
-            CommandRequestError { address, .. } => {
-                write!(f, "Could not run command on remote Brane instance '{address}': request failed: remote returned status")
-            },
-            ValueParseError { address, raw, .. } => write!(f, "Could not parse '{raw}' sent by remote '{address}' as a value"),
-            ExecDenied { .. } => write!(f, "Workflow was denied"),
-            ExecError { .. } => write!(f, "Failed to run workflow"),
-
-            UnknownDataset { name } => write!(f, "Unknown dataset '{name}'"),
-            UnavailableDataset { name, locs } => write!(
-                f,
-                "Unavailable dataset '{}'{}",
-                name,
-                if !locs.is_empty() {
-                    format!("; it is available at {}", PrettyListFormatter::new(locs.iter().map(|l| format!("'{l}'")), "or"))
-                } else {
-                    String::new()
-                }
-            ),
-            DataDownloadError { .. } => write!(f, "Failed to download remote dataset"),
-
-            StdinReadError { .. } => write!(f, "Failed to read source from stdin"),
-            FileReadError { path, .. } => write!(f, "Failed to read source from file '{}'", path.display()),
-            LoginFileError { err } => write!(f, "{err}"),
-        }
-    }
-}
-impl Error for RunError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use RunError::*;
-        match self {
-            WriteError { err } => Some(err),
-
-            LocalPackageIndexError { err } => Some(err),
-            LocalDataIndexError { err } => Some(err),
-            PackagesDirError { err } => Some(err),
-            DatasetsDirError { err } => Some(err),
-            ResultsDirCreateError { err } => Some(err),
-
-            InstanceInfoError { err } => err.source(),
-            ActiveInstanceReadError { err } => Some(err),
-            InstancePathError { err, .. } => Some(err),
-            RemotePackageIndexError { err, .. } => Some(err),
-            RemoteDataIndexError { err, .. } => Some(err),
-            RemoteDelegatesError { err, .. } => Some(err),
-            ClientConnectError { err, .. } => Some(err),
-            AppIdError { err, .. } => Some(err),
-            SessionCreateError { err, .. } => Some(err),
-
-            CompileError { .. } => None,
-            WorkflowSerializeError { err } => Some(err),
-            CommandRequestError { err, .. } => Some(err),
-            ValueParseError { err, .. } => Some(err),
-            ExecDenied { err } => Some(&**err),
-            ExecError { err } => Some(&**err),
-
-            UnknownDataset { .. } => None,
-            UnavailableDataset { .. } => None,
-            DataDownloadError { err } => Some(err),
-
-            StdinReadError { err } => Some(err),
-            FileReadError { err, .. } => Some(err),
-            LoginFileError { err } => err.source(),
-        }
-    }
-}
-impl From<std::io::Error> for RunError {
-    #[inline]
-    fn from(value: std::io::Error) -> Self { RunError::WriteError { err: value } }
-}
-
-
 
 /// Collects errors during the test subcommand.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum TestError {
     /// Failed to get the local data index.
-    DataIndexError { err: brane_tsk::local::Error },
+    #[error("Failed to load local data index")]
+    DataIndexError { source: brane_tsk::local::Error },
     /// Failed to prompt the user for the function/input selection.
-    InputError { err: brane_tsk::input::Error },
+    #[error("Failed to ask the user (you!) for input")]
+    InputError { source: brane_tsk::input::Error },
 
     /// Failed to create a temporary directory
-    TempDirError { err: std::io::Error },
+    #[error("Failed to create temporary results directory")]
+    TempDirError { source: std::io::Error },
     /// We can't access a dataset in the local instance.
+    #[error("Dataset '{}' is unavailable{}", name, if !locs.is_empty() { format!( "; however, locations {} do (try to get download permission to those datasets)", locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")) } else { String::new() })]
     DatasetUnavailable { name: String, locs: Vec<String> },
     /// The given dataset was unknown to us.
+    #[error("Unknown dataset '{name}'")]
     UnknownDataset { name: String },
     /// Failed to get the general package directory.
-    PackagesDirError { err: UtilError },
+    #[error("Failed to get packages directory")]
+    PackagesDirError { source: UtilError },
     /// Failed to get the general dataset directory.
-    DatasetsDirError { err: UtilError },
+    #[error("Failed to get datasets directory")]
+    DatasetsDirError { source: UtilError },
     /// Failed to get the directory of a package.
-    PackageDirError { name: String, version: Version, err: UtilError },
+    #[error("Failed to get directory of package '{name}' (version {version})")]
+    PackageDirError { name: String, version: Version, source: UtilError },
     /// Failed to read the PackageInfo of the given package.
-    PackageInfoError { name: String, version: Version, err: specifications::package::PackageInfoError },
+    #[error("Failed to read package info for package '{name}' (version {version})")]
+    PackageInfoError { name: String, version: Version, source: specifications::package::PackageInfoError },
 
     /// Failed to initialize the offline VM.
-    InitializeError { err: RunError },
+    #[error("Failed to initialize offline VM")]
+    InitializeError { source: RunError },
     /// Failed to run the offline VM.
-    RunError { err: RunError },
+    #[error("Failed to run offline VM")]
+    RunError { source: RunError },
     /// Failed to read the intermediate results file.
-    IntermediateResultFileReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read intermediate result file '{}'", path.display())]
+    IntermediateResultFileReadError { path: PathBuf, source: std::io::Error },
 }
-impl Display for TestError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use TestError::*;
-        match self {
-            DataIndexError { err } => write!(f, "Failed to load local data index: {err}"),
-            InputError { err } => write!(f, "Failed to ask the user (you!) for input: {}", err.trace()),
-
-            TempDirError { err } => write!(f, "Failed to create temporary results directory: {err}"),
-            DatasetUnavailable { name, locs } => write!(
-                f,
-                "Dataset '{}' is unavailable{}",
-                name,
-                if !locs.is_empty() {
-                    format!(
-                        "; however, locations {} do (try to get download permission to those datasets)",
-                        locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")
-                    )
-                } else {
-                    String::new()
-                }
-            ),
-            UnknownDataset { name } => write!(f, "Unknown dataset '{name}'"),
-            PackagesDirError { err } => write!(f, "Failed to get packages directory: {err}"),
-            DatasetsDirError { err } => write!(f, "Failed to get datasets directory: {err}"),
-            PackageDirError { name, version, err } => write!(f, "Failed to get directory of package '{name}' (version {version}): {err}"),
-            PackageInfoError { name, version, err } => write!(f, "Failed to read package info for package '{name}' (version {version}): {err}"),
-
-            InitializeError { err } => write!(f, "Failed to initialize offline VM: {err}"),
-            RunError { err } => write!(f, "Failed to run offline VM: {err}"),
-            IntermediateResultFileReadError { path, err } => write!(f, "Failed to read intermediate result file '{}': {}", path.display(), err),
-        }
-    }
-}
-impl Error for TestError {}
-
-
 
 /// Collects errors relating to the verify command.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum VerifyError {
     /// Failed to verify the config
-    ConfigFailed { err: brane_cfg::infra::Error },
+    #[error("Failed to verify configuration")]
+    ConfigFailed { source: brane_cfg::infra::Error },
 }
-impl Display for VerifyError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use VerifyError::*;
-        match self {
-            ConfigFailed { err } => write!(f, "Failed to verify configuration: {err}"),
-        }
-    }
-}
-impl Error for VerifyError {}
-
-
 
 /// Collects errors relating to the version command.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum VersionError {
     /// Could not get the host architecture
-    HostArchError { err: specifications::arch::ArchError },
+    #[error("Could not get the host processor architecture")]
+    HostArchError { source: specifications::arch::ArchError },
     /// Could not parse a Version number.
-    VersionParseError { raw: String, err: specifications::version::ParseError },
+    #[error("Could parse '{raw}' as Version")]
+    VersionParseError { raw: String, source: specifications::version::ParseError },
 
     /// Could not discover if the instance existed.
-    InstanceInfoExistsError { err: InstanceError },
+    #[error("Could not check if active instance exists")]
+    InstanceInfoExistsError { source: InstanceError },
     /// Could not open the login file
-    InstanceInfoError { err: InstanceError },
+    #[error(transparent)]
+    InstanceInfoError { source: InstanceError },
     /// Could not perform the request
-    RequestError { url: String, err: reqwest::Error },
+    #[error("Could not perform request to '{url}'")]
+    RequestError { url: String, source: reqwest::Error },
     /// The request returned a non-200 exit code
+    #[error("Request to '{}' returned non-zero exit code {} ({})", url, status.as_u16(), status.canonical_reason().unwrap_or("<???>"))]
     RequestFailure { url: String, status: reqwest::StatusCode },
     /// The request's body could not be get.
-    RequestBodyError { url: String, err: reqwest::Error },
+    #[error("Could not get body from response from '{url}'")]
+    RequestBodyError { url: String, source: reqwest::Error },
 }
-impl Display for VersionError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use VersionError::*;
-        match self {
-            HostArchError { err } => write!(f, "Could not get the host processor architecture: {err}"),
-            VersionParseError { raw, err } => write!(f, "Could parse '{raw}' as Version: {err}"),
-
-            InstanceInfoExistsError { err } => write!(f, "Could not check if active instance exists: {err}"),
-            InstanceInfoError { err } => write!(f, "{err}"),
-            RequestError { url, err } => write!(f, "Could not perform request to '{url}': {err}"),
-            RequestFailure { url, status } => {
-                write!(f, "Request to '{}' returned non-zero exit code {} ({})", url, status.as_u16(), status.canonical_reason().unwrap_or("<???>"))
-            },
-            RequestBodyError { url, err } => write!(f, "Could not get body from response from '{url}': {err}"),
-        }
-    }
-}
-impl Error for VersionError {}
-
-
 
 /// Collects errors of utilities that don't find an origin in just one subcommand.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum UtilError {
     /// Could not connect to the local Docker instance
-    DockerConnectionFailed { err: bollard::errors::Error },
+    #[error("Could not connect to local Docker instance")]
+    DockerConnectionFailed { source: bollard::errors::Error },
     /// Could not get the version of the Docker daemon
-    DockerVersionError { err: bollard::errors::Error },
+    #[error("Could not get version of the local Docker instance")]
+    DockerVersionError { source: bollard::errors::Error },
     /// The docker daemon returned something, but not the version
+    #[error("Local Docker instance doesn't report a version number")]
     DockerNoVersion,
     /// The version reported by the Docker daemon is not a valid version
-    IllegalDockerVersion { version: String, err: VersionParseError },
+    #[error("Local Docker instance reports unparseable version '{version}'")]
+    IllegalDockerVersion { version: String, source: VersionParseError },
     /// Could not launch the command to get the Buildx version
-    BuildxLaunchError { command: String, err: std::io::Error },
+    #[error("Could not run command '{command}' to get Buildx version information")]
+    BuildxLaunchError { command: String, source: std::io::Error },
     /// The Buildx version in the buildx command does not have at least two parts, separated by spaces
+    #[error("Illegal Buildx version '{version}': did not find second part (separted by spaces) with version number")]
     BuildxVersionNoParts { version: String },
     /// The Buildx version is not prepended with a 'v'
+    #[error("Illegal Buildx version '{version}': did not find 'v' prepending version number")]
     BuildxVersionNoV { version: String },
     /// The version reported by Buildx is not a valid version
-    IllegalBuildxVersion { version: String, err: VersionParseError },
+    #[error("Buildx reports unparseable version '{version}'")]
+    IllegalBuildxVersion { version: String, source: VersionParseError },
 
     /// Could not read from a given directory
-    DirectoryReadError { dir: PathBuf, err: std::io::Error },
+    #[error("Could not read from directory '{}'", dir.display())]
+    DirectoryReadError { dir: PathBuf, source: std::io::Error },
     /// Could not automatically determine package file inside a directory.
+    #[error("Could not determine package file in directory '{}'; specify it manually with '--file'", dir.display())]
     UndeterminedPackageFile { dir: PathBuf },
 
     /// Could not open the main package file of the package to build.
-    PackageFileOpenError { file: PathBuf, err: std::io::Error },
+    #[error("Could not open package file '{}'", file.display())]
+    PackageFileOpenError { file: PathBuf, source: std::io::Error },
     /// Could not read the main package file of the package to build.
-    PackageFileReadError { file: PathBuf, err: std::io::Error },
+    #[error("Could not read from package file '{}'", file.display())]
+    PackageFileReadError { file: PathBuf, source: std::io::Error },
     /// Could not automatically determine package kind based on the file.
+    #[error("Could not determine package from package file '{}'; specify it manually with '--kind'", file.display())]
     UndeterminedPackageKind { file: PathBuf },
 
     /// Could not find the user config folder
+    #[error("Could not find the user's config directory for your OS (reported as {})", std::env::consts::OS)]
     UserConfigDirNotFound,
     /// Could not create brane's folder in the config folder
-    BraneConfigDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create Brane config directory '{}'", path.display())]
+    BraneConfigDirCreateError { path: PathBuf, source: std::io::Error },
     /// Could not find brane's folder in the config folder
+    #[error("Brane config directory '{}' not found", path.display())]
     BraneConfigDirNotFound { path: PathBuf },
 
     /// Could not create Brane's history file
-    HistoryFileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create history file '{}' for the REPL", path.display())]
+    HistoryFileCreateError { path: PathBuf, source: std::io::Error },
     /// Could not find Brane's history file
+    #[error("History file '{}' for the REPL does not exist", path.display())]
     HistoryFileNotFound { path: PathBuf },
 
     /// Could not find the user local data folder
+    #[error("Could not find the user's local data directory for your OS (reported as {})", std::env::consts::OS)]
     UserLocalDataDirNotFound,
     /// Could not find create brane's folder in the data folder
-    BraneDataDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create Brane data directory '{}'", path.display())]
+    BraneDataDirCreateError { path: PathBuf, source: std::io::Error },
     /// Could not find brane's folder in the data folder
+    #[error("Brane data directory '{}' not found", path.display())]
     BraneDataDirNotFound { path: PathBuf },
 
     /// Could not find create the package folder inside brane's data folder
-    BranePackageDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create Brane package directory '{}'", path.display())]
+    BranePackageDirCreateError { path: PathBuf, source: std::io::Error },
     /// Could not find the package folder inside brane's data folder
+    #[error("Brane package directory '{}' not found", path.display())]
     BranePackageDirNotFound { path: PathBuf },
 
     /// Could not create the dataset folder inside brane's data folder
-    BraneDatasetsDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Could not create Brane datasets directory '{}'", path.display())]
+    BraneDatasetsDirCreateError { path: PathBuf, source: std::io::Error },
     /// Could not find the dataset folder inside brane's data folder.
+    #[error("Brane datasets directory '{}' not found", path.display())]
     BraneDatasetsDirNotFound { path: PathBuf },
 
     /// Failed to read the versions in a package's directory.
-    VersionsError { err: brane_tsk::errors::LocalError },
+    #[error("Failed to read package versions")]
+    VersionsError { source: brane_tsk::errors::LocalError },
 
     /// Could not create the directory for a package
-    PackageDirCreateError { package: String, path: PathBuf, err: std::io::Error },
+    #[error("Could not create directory for package '{}' (path: '{}')", package, path.display())]
+    PackageDirCreateError { package: String, path: PathBuf, source: std::io::Error },
     /// The target package directory does not exist
+    #[error("Directory for package '{}' does not exist (path: '{}')", package, path.display())]
     PackageDirNotFound { package: String, path: PathBuf },
     /// Could not create a new directory for the given version
-    VersionDirCreateError { package: String, version: Version, path: PathBuf, err: std::io::Error },
+    #[error("Could not create directory for package '{}', version: {} (path: '{}')", package, version, path.display())]
+    VersionDirCreateError { package: String, version: Version, path: PathBuf, source: std::io::Error },
     /// The target package/version directory does not exist
+    #[error("Directory for package '{}', version: {} does not exist (path: '{}')", package, version, path.display())]
     VersionDirNotFound { package: String, version: Version, path: PathBuf },
 
     /// Could not create the dataset folder for a specific dataset
-    BraneDatasetDirCreateError { name: String, path: PathBuf, err: std::io::Error },
+    #[error("Could not create Brane dataset directory '{}' for dataset '{}'", path.display(), name)]
+    BraneDatasetDirCreateError { name: String, path: PathBuf, source: std::io::Error },
     /// Could not find the dataset folder for a specific dataset.
+    #[error("Brane dataset directory '{}' for dataset '{}' not found", path.display(), name)]
     BraneDatasetDirNotFound { name: String, path: PathBuf },
 
     /// Could not create the instances folder.
-    BraneInstancesDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create Brane instance directory '{}'", path.display())]
+    BraneInstancesDirCreateError { path: PathBuf, source: std::io::Error },
     /// The instances folder did not exist.
+    #[error("Brane instance directory '{}' not found", path.display())]
     BraneInstancesDirNotFound { path: PathBuf },
     /// Could not create the instance folder for a specific instance.
-    BraneInstanceDirCreateError { path: PathBuf, name: String, err: std::io::Error },
+    #[error("Failed to create directory '{}' for new instance '{}'", path.display(), name)]
+    BraneInstanceDirCreateError { path: PathBuf, name: String, source: std::io::Error },
     /// The instance folder for a specific instance did not exist.
+    #[error("Brane instance directory '{}' for instance '{}' not found", path.display(), name)]
     BraneInstanceDirNotFound { path: PathBuf, name: String },
 
     /// The given name is not a valid bakery name.
+    #[error("The given name '{name}' is not a valid name; expected alphanumeric or underscore characters")]
     InvalidBakeryName { name: String },
 }
-impl Display for UtilError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use UtilError::*;
-        match self {
-            DockerConnectionFailed { err } => write!(f, "Could not connect to local Docker instance: {err}"),
-            DockerVersionError { err } => write!(f, "Could not get version of the local Docker instance: {err}"),
-            DockerNoVersion => write!(f, "Local Docker instance doesn't report a version number"),
-            IllegalDockerVersion { version, err } => write!(f, "Local Docker instance reports unparseable version '{version}': {err}"),
-            BuildxLaunchError { command, err } => write!(f, "Could not run command '{command}' to get Buildx version information: {err}"),
-            BuildxVersionNoParts { version } => {
-                write!(f, "Illegal Buildx version '{version}': did not find second part (separted by spaces) with version number")
-            },
-            BuildxVersionNoV { version } => write!(f, "Illegal Buildx version '{version}': did not find 'v' prepending version number"),
-            IllegalBuildxVersion { version, err } => write!(f, "Buildx reports unparseable version '{version}': {err}"),
-
-            DirectoryReadError { dir, err } => write!(f, "Could not read from directory '{}': {}", dir.display(), err),
-            UndeterminedPackageFile { dir } => {
-                write!(f, "Could not determine package file in directory '{}'; specify it manually with '--file'", dir.display())
-            },
-
-            PackageFileOpenError { file, err } => write!(f, "Could not open package file '{}': {}", file.display(), err),
-            PackageFileReadError { file, err } => write!(f, "Could not read from package file '{}': {}", file.display(), err),
-            UndeterminedPackageKind { file } => {
-                write!(f, "Could not determine package from package file '{}'; specify it manually with '--kind'", file.display())
-            },
-
-            UserConfigDirNotFound => write!(f, "Could not find the user's config directory for your OS (reported as {})", std::env::consts::OS),
-            BraneConfigDirCreateError { path, err } => write!(f, "Could not create Brane config directory '{}': {}", path.display(), err),
-            BraneConfigDirNotFound { path } => write!(f, "Brane config directory '{}' not found", path.display()),
-
-            HistoryFileCreateError { path, err } => write!(f, "Could not create history file '{}' for the REPL: {}", path.display(), err),
-            HistoryFileNotFound { path } => write!(f, "History file '{}' for the REPL does not exist", path.display()),
-
-            UserLocalDataDirNotFound => {
-                write!(f, "Could not find the user's local data directory for your OS (reported as {})", std::env::consts::OS)
-            },
-            BraneDataDirCreateError { path, err } => write!(f, "Could not create Brane data directory '{}': {}", path.display(), err),
-            BraneDataDirNotFound { path } => write!(f, "Brane data directory '{}' not found", path.display()),
-
-            BranePackageDirCreateError { path, err } => write!(f, "Could not create Brane package directory '{}': {}", path.display(), err),
-            BranePackageDirNotFound { path } => write!(f, "Brane package directory '{}' not found", path.display()),
-
-            BraneDatasetsDirCreateError { path, err } => write!(f, "Could not create Brane datasets directory '{}': {}", path.display(), err),
-            BraneDatasetsDirNotFound { path } => write!(f, "Brane datasets directory '{}' not found", path.display()),
-
-            VersionsError { err } => write!(f, "Failed to read package versions: {err}"),
-
-            PackageDirCreateError { package, path, err } => {
-                write!(f, "Could not create directory for package '{}' (path: '{}'): {}", package, path.display(), err)
-            },
-            PackageDirNotFound { package, path } => write!(f, "Directory for package '{}' does not exist (path: '{}')", package, path.display()),
-            VersionDirCreateError { package, version, path, err } => {
-                write!(f, "Could not create directory for package '{}', version: {} (path: '{}'): {}", package, version, path.display(), err)
-            },
-            VersionDirNotFound { package, version, path } => {
-                write!(f, "Directory for package '{}', version: {} does not exist (path: '{}')", package, version, path.display())
-            },
-
-            BraneDatasetDirCreateError { name, path, err } => {
-                write!(f, "Could not create Brane dataset directory '{}' for dataset '{}': {}", path.display(), name, err)
-            },
-            BraneDatasetDirNotFound { name, path } => write!(f, "Brane dataset directory '{}' for dataset '{}' not found", path.display(), name),
-
-            BraneInstancesDirCreateError { path, err } => write!(f, "Failed to create Brane instance directory '{}': {}", path.display(), err),
-            BraneInstancesDirNotFound { path } => write!(f, "Brane instance directory '{}' not found", path.display()),
-            BraneInstanceDirCreateError { path, name, err } => {
-                write!(f, "Failed to create directory '{}' for new instance '{}': {}", path.display(), name, err)
-            },
-            BraneInstanceDirNotFound { path, name } => write!(f, "Brane instance directory '{}' for instance '{}' not found", path.display(), name),
-
-            InvalidBakeryName { name } => write!(f, "The given name '{name}' is not a valid name; expected alphanumeric or underscore characters"),
-        }
-    }
-}
-impl Error for UtilError {}
-
-
 
 /// Defines errors that relate to finding our directories.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DirError {
     /// Failed to find a user directory. The `what` hints at the kind of user directory (fill in "\<what\> directory", e.g., "config", "data", ...)
+    #[error("Failed to find user {} directory", what)]
     UserDirError { what: &'static str },
     /// Failed to read the softlink.
-    SoftlinkReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read softlink '{}'", path.display())]
+    SoftlinkReadError { path: PathBuf, source: std::io::Error },
 }
-impl Display for DirError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DirError::*;
-        match self {
-            UserDirError { what } => write!(f, "Failed to find user {} directory", what),
-            SoftlinkReadError { path, err } => write!(f, "Failed to read softlink '{}': {}", path.display(), err),
-        }
-    }
-}
-impl Error for DirError {}
-
-
 
 /// Declares errors that relate to parsing hostnames from a string.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum HostnameParseError {
     /// The scheme contained an illegal character.
+    #[error("URL scheme '{raw}' contains illegal character '{c}'")]
     IllegalSchemeChar { raw: String, c: char },
     /// The hostname contained a path separator.
+    #[error("Hostname '{raw}' is not just a hostname (it contains a nested path)")]
     HostnameContainsPath { raw: String },
 }
-impl Display for HostnameParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use HostnameParseError::*;
-        match self {
-            IllegalSchemeChar { raw, c } => write!(f, "URL scheme '{raw}' contains illegal character '{c}'"),
-            HostnameContainsPath { raw } => write!(f, "Hostname '{raw}' is not just a hostname (it contains a nested path)"),
-        }
-    }
-}
-impl Error for HostnameParseError {}
-
-
 
 /// Declares errors that relate to the offline VM.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum OfflineVmError {
     /// Failed to plan a workflow.
-    PlanError { err: brane_tsk::errors::PlanError },
+    #[error("Failed to plan workflow")]
+    PlanError { source: brane_tsk::errors::PlanError },
     /// Failed to run a workflow.
-    ExecError { err: brane_exe::Error },
+    #[error("Failed to execute workflow")]
+    ExecError { source: brane_exe::Error },
 }
-impl Display for OfflineVmError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use OfflineVmError::*;
-        match self {
-            PlanError { err } => write!(f, "Failed to plan workflow: {err}"),
-            ExecError { err } => write!(f, "Failed to execute workflow: {err}"),
-        }
-    }
-}
-impl Error for OfflineVmError {}
-
-
 
 /// A really specific error enum for errors relating to fetching delegates.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DelegatesError {
     /// Failed to sent the GET-request to fetch the map.
-    RequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send delegates request to '{address}'")]
+    RequestError { address: String, source: reqwest::Error },
     /// The request returned a non-2xx status code.
+    #[error("Request to '{}' failed with status code {} ({}){}", address, code, code.canonical_reason().unwrap_or("???"), if let Some(msg) = message { format!(": {msg}") } else { String::new() })]
     RequestFailure { address: String, code: StatusCode, message: Option<String> },
     /// Failed to get the request body properly.
-    ResponseTextError { address: String, err: reqwest::Error },
+    #[error("Failed to get body from response sent by '{address}' as text")]
+    ResponseTextError { address: String, source: reqwest::Error },
     /// Failed to parse the request body properly.
-    ResponseParseError { address: String, raw: String, err: serde_json::Error },
+    #[error("Failed to parse response body '{raw}' sent by '{address}' as a delegate map")]
+    ResponseParseError { address: String, raw: String, source: serde_json::Error },
 }
-impl Display for DelegatesError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DelegatesError::*;
-        match self {
-            RequestError { address, err } => write!(f, "Failed to send delegates request to '{address}': {err}"),
-            RequestFailure { address, code, message } => write!(
-                f,
-                "Request to '{}' failed with status code {} ({}){}",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(msg) = message { format!(": {msg}") } else { String::new() }
-            ),
-            ResponseTextError { address, err } => write!(f, "Failed to get body from response sent by '{address}' as text: {err}"),
-            ResponseParseError { address, raw, err } => {
-                write!(f, "Failed to parse response body '{raw}' sent by '{address}' as a delegate map: {err}")
-            },
-        }
-    }
-}
-impl Error for DelegatesError {}

--- a/brane-cli/src/errors.rs
+++ b/brane-cli/src/errors.rs
@@ -681,29 +681,63 @@ impl Error for CheckError {
 #[derive(Debug)]
 pub enum DataError {
     /// Failed to sent the GET-request to fetch the dfelegate.
-    RequestError { what: &'static str, address: String, err: reqwest::Error },
+    RequestError {
+        what:    &'static str,
+        address: String,
+        err:     reqwest::Error,
+    },
     /// The request returned a non-2xx status code.
-    RequestFailure { address: String, code: StatusCode, message: Option<String> },
+    RequestFailure {
+        address: String,
+        code:    StatusCode,
+        message: Option<String>,
+    },
     /// Failed to get the request body properly.
-    ResponseTextError { address: String, err: reqwest::Error },
+    ResponseTextError {
+        address: String,
+        err:     reqwest::Error,
+    },
     // /// Failed to load the keypair.
     // KeypairLoadError{ err: brane_cfg::certs::Error },
     // /// Failed to load the certificate root store.
     // StoreLoadError{ err: brane_cfg::certs::Error },
     /// Failed to open/read a given file.
-    FileReadError { what: &'static str, path: PathBuf, err: std::io::Error },
+    FileReadError {
+        what: &'static str,
+        path: PathBuf,
+        err:  std::io::Error,
+    },
     /// Failed to get the directory of the certificates.
-    CertsDirError { err: CertsError },
+    CertsDirError {
+        err: CertsError,
+    },
     /// Failed to parse an identity file.
-    IdentityFileError { path: PathBuf, err: reqwest::Error },
+    IdentityFileError {
+        path: PathBuf,
+        err:  reqwest::Error,
+    },
     /// Failed to parse a certificate.
-    CertificateError { path: PathBuf, err: reqwest::Error },
+    CertificateError {
+        path: PathBuf,
+        err:  reqwest::Error,
+    },
     /// A directory was not a directory but a file.
-    DirNotADirError { what: &'static str, path: PathBuf },
+    DirNotADirError {
+        what: &'static str,
+        path: PathBuf,
+    },
     /// A directory could not be removed.
-    DirRemoveError { what: &'static str, path: PathBuf, err: std::io::Error },
+    DirRemoveError {
+        what: &'static str,
+        path: PathBuf,
+        err:  std::io::Error,
+    },
     /// A directory could not be created.
-    DirCreateError { what: &'static str, path: PathBuf, err: std::io::Error },
+    DirCreateError {
+        what: &'static str,
+        path: PathBuf,
+        err:  std::io::Error,
+    },
     // /// The given certificate file was empty.
     // EmptyCertFile{ path: PathBuf },
     // /// Failed to parse the given key/cert pair as an IdentityFile.
@@ -711,75 +745,146 @@ pub enum DataError {
     // /// Failed to load the given certificate as PEM root certificate.
     // RootError{ cafile: PathBuf, err: reqwest::Error },
     /// Failed to create a temporary directory.
-    TempDirError { err: std::io::Error },
+    TempDirError {
+        err: std::io::Error,
+    },
     /// Failed to create the dataset directory.
-    DatasetDirError { name: String, err: UtilError },
+    DatasetDirError {
+        name: String,
+        err:  UtilError,
+    },
     /// Failed to create a new reqwest proxy
-    ProxyCreateError { address: String, err: reqwest::Error },
+    ProxyCreateError {
+        address: String,
+        err:     reqwest::Error,
+    },
     /// Failed to create a new reqwest client
-    ClientCreateError { err: reqwest::Error },
+    ClientCreateError {
+        err: reqwest::Error,
+    },
     /// Failed to reach the next chunk of data.
-    DownloadStreamError { address: String, err: reqwest::Error },
+    DownloadStreamError {
+        address: String,
+        err:     reqwest::Error,
+    },
     /// Failed to create the file to which we write the download stream.
-    TarCreateError { path: PathBuf, err: std::io::Error },
+    TarCreateError {
+        path: PathBuf,
+        err:  std::io::Error,
+    },
     // /// Failed to (re-)open the file to which we've written the download stream.
     // TarOpenError{ path: PathBuf, err: std::io::Error },
     /// Failed to write to the file where we write the download stream.
-    TarWriteError { path: PathBuf, err: std::io::Error },
+    TarWriteError {
+        path: PathBuf,
+        err:  std::io::Error,
+    },
     /// Failed to extract the downloaded tar.
     // TarExtractError{ source: PathBuf, target: PathBuf, err: std::io::Error },
-    TarExtractError { err: brane_shr::fs::Error },
+    TarExtractError {
+        err: brane_shr::fs::Error,
+    },
 
     /// Failed to get the datasets folder
-    DatasetsError { err: UtilError },
+    DatasetsError {
+        err: UtilError,
+    },
     /// Failed to fetch the local data index.
-    LocalDataIndexError { err: brane_tsk::local::Error },
+    LocalDataIndexError {
+        err: brane_tsk::local::Error,
+    },
 
     /// Failed to load the given AssetInfo file.
-    AssetFileError { path: PathBuf, err: specifications::data::AssetInfoError },
+    AssetFileError {
+        path: PathBuf,
+        err:  specifications::data::AssetInfoError,
+    },
     /// Could not canonicalize the given (relative) path.
-    FileCanonicalizeError { path: PathBuf, err: std::io::Error },
+    FileCanonicalizeError {
+        path: PathBuf,
+        err:  std::io::Error,
+    },
     /// The given file does not exist
-    FileNotFoundError { path: PathBuf },
+    FileNotFoundError {
+        path: PathBuf,
+    },
     /// The given file is not a file
-    FileNotAFileError { path: PathBuf },
+    FileNotAFileError {
+        path: PathBuf,
+    },
     /// Failed to create the dataset's directory.
-    DatasetDirCreateError { err: UtilError },
+    DatasetDirCreateError {
+        err: UtilError,
+    },
     /// A dataset with the given name already exists.
-    DuplicateDatasetError { name: String },
+    DuplicateDatasetError {
+        name: String,
+    },
     /// Failed to copy the data directory over.
-    DataCopyError { err: brane_shr::fs::Error },
+    DataCopyError {
+        err: brane_shr::fs::Error,
+    },
     /// Failed to write the DataInfo.
-    DataInfoWriteError { err: specifications::data::DataInfoError },
+    DataInfoWriteError {
+        err: specifications::data::DataInfoError,
+    },
 
     /// The given "keypair" was not a keypair at all
-    NoEqualsInKeyPair { raw: String },
+    NoEqualsInKeyPair {
+        raw: String,
+    },
     /// Failed to fetch the login file.
-    InstanceInfoError { err: InstanceError },
+    InstanceInfoError {
+        err: InstanceError,
+    },
     /// Failed to get the path of the active instance.
-    ActiveInstanceReadError { err: InstanceError },
+    ActiveInstanceReadError {
+        err: InstanceError,
+    },
     /// Failed to get the active instance.
-    InstancePathError { name: String, err: InstanceError },
+    InstancePathError {
+        name: String,
+        err:  InstanceError,
+    },
     /// Failed to create the remote data index.
-    RemoteDataIndexError { address: String, err: brane_tsk::errors::ApiError },
+    RemoteDataIndexError {
+        address: String,
+        err:     brane_tsk::errors::ApiError,
+    },
     /// Failed to select the download location in case there are multiple.
-    DataSelectError { err: dialoguer::Error },
+    DataSelectError {
+        err: dialoguer::Error,
+    },
     /// We encountered a location we did not know
-    UnknownLocation { name: String },
+    UnknownLocation {
+        name: String,
+    },
 
     /// The given dataset was unknown to us.
-    UnknownDataset { name: String },
+    UnknownDataset {
+        name: String,
+    },
     /// the given dataset was known but not locally available.
-    UnavailableDataset { name: String, locs: Vec<String> },
+    UnavailableDataset {
+        name: String,
+        locs: Vec<String>,
+    },
 
     // /// Failed to ensure the directory of the given dataset.
     // DatasetDirError{ err: UtilError },
     /// Failed to ask the user for consent before removing the dataset.
-    ConfirmationError { err: dialoguer::Error },
+    ConfirmationError {
+        err: dialoguer::Error,
+    },
     /// Failed to remove the dataset's directory
-    RemoveError { path: PathBuf, err: std::io::Error },
-    /// Could not serialize workflow when
-    WorkflowSerializeError { context: String, err: serde_json::Error },
+    RemoveError {
+        path: PathBuf,
+        err:  std::io::Error,
+    },
+    WorkflowSerializeError {
+        context: String,
+        err:     serde_json::Error,
+    },
 }
 impl Display for DataError {
     #[inline]

--- a/brane-cli/src/errors.rs
+++ b/brane-cli/src/errors.rs
@@ -780,7 +780,6 @@ pub enum DataError {
         err:  std::io::Error,
     },
     /// Failed to extract the downloaded tar.
-    // TarExtractError{ source: PathBuf, target: PathBuf, err: std::io::Error },
     TarExtractError {
         err: brane_shr::fs::Error,
     },

--- a/brane-cli/src/verify.rs
+++ b/brane-cli/src/verify.rs
@@ -32,6 +32,6 @@ pub fn config(infra: impl AsRef<Path>) -> Result<(), Error> {
     // Verify the infra file, which will validate the secrets file
     match InfraFile::from_path(infra.as_ref()) {
         Ok(_) => Ok(()),
-        Err(err) => Err(Error::ConfigFailed { err }),
+        Err(source) => Err(Error::ConfigFailed { source }),
     }
 }

--- a/brane-cli/src/vm.rs
+++ b/brane-cli/src/vm.rs
@@ -114,12 +114,7 @@ impl VmPlugin for OfflinePlugin {
         let binds: Vec<VolumeBind> = prof
             .time_fut("argument preprocessing", docker::preprocess_args(&mut info.args, &info.input, info.result, None::<String>, results_dir))
             .await?;
-        let params: String = match serde_json::to_string(&info.args) {
-            Ok(params) => params,
-            Err(err) => {
-                return Err(ExecuteError::ArgsEncodeError { err });
-            },
-        };
+        let params: String = serde_json::to_string(&info.args).map_err(|source| ExecuteError::ArgsEncodeError { source })?;
 
         // Create an ExecuteInfo with that
         let image: Image = Image::new(info.package_name, Some(info.package_version), Some(pinfo.digest.as_ref().unwrap()));
@@ -147,12 +142,10 @@ impl VmPlugin for OfflinePlugin {
 
         // We can now execute the task on the local Docker daemon
         debug!("Executing task '{}'...", info.name);
-        let (code, stdout, stderr) = match prof.time_fut("execution", docker::run_and_wait(docker_opts, einfo, keep_container)).await {
-            Ok(res) => res,
-            Err(err) => {
-                return Err(ExecuteError::DockerError { name: info.name.into(), image: Box::new(image), err });
-            },
-        };
+        let (code, stdout, stderr) = prof
+            .time_fut("execution", docker::run_and_wait(docker_opts, einfo, keep_container))
+            .await
+            .map_err(|source| ExecuteError::DockerError { name: info.name.into(), image: Box::new(image.clone()), source })?;
         debug!("Container return code: {}", code);
         debug!("Container stdout/stderr:\n\nstdout:\n{}\n\nstderr:\n{}\n", BlockFormatter::new(&stdout), BlockFormatter::new(&stderr));
 
@@ -165,12 +158,7 @@ impl VmPlugin for OfflinePlugin {
         let dec = prof.time("Decoding");
         let output = stdout.lines().last().unwrap_or_default().to_string();
         let raw: String = decode_base64(output)?;
-        let value: Option<FullValue> = match serde_json::from_str(&raw) {
-            Ok(value) => value,
-            Err(err) => {
-                return Err(ExecuteError::JsonDecodeError { raw, err });
-            },
-        };
+        let value: Option<FullValue> = serde_json::from_str(&raw).map_err(|source| ExecuteError::JsonDecodeError { raw, source })?;
         dec.stop();
 
         // Done, return the value
@@ -246,9 +234,9 @@ impl VmPlugin for OfflinePlugin {
                 match access {
                     AccessKind::File { path: data_path } => {
                         // Simply copy the one directory over the other and it's updated
-                        if let Err(err) = copy_dir_recursively_async(results_dir.join(path), data_path).await {
-                            return Err(CommitError::DataCopyError { err });
-                        }
+                        copy_dir_recursively_async(results_dir.join(path), data_path)
+                            .await
+                            .map_err(|source| CommitError::DataCopyError { source })?;
                     },
                 }
             } else {
@@ -263,9 +251,7 @@ impl VmPlugin for OfflinePlugin {
                 if dir.exists() {
                     return Err(CommitError::DataDirNotADir { path: dir });
                 }
-                if let Err(err) = tfs::create_dir_all(&dir).await {
-                    return Err(CommitError::DataDirCreateError { path: dir, err });
-                }
+                tfs::create_dir_all(&dir).await.map_err(|source| CommitError::DataDirCreateError { path: dir.clone(), source })?;
             }
 
             // Create a new DataInfo struct
@@ -280,29 +266,16 @@ impl VmPlugin for OfflinePlugin {
 
             // Write it to the target folder
             let info_path: PathBuf = dir.join("data.yml");
-            let mut handle: tfs::File = match tfs::File::create(&info_path).await {
-                Ok(handle) => handle,
-                Err(err) => {
-                    return Err(CommitError::DataInfoCreateError { path: info_path, err });
-                },
-            };
-            let sinfo: String = match serde_yaml::to_string(&info) {
-                Ok(sinfo) => sinfo,
-                Err(err) => {
-                    return Err(CommitError::DataInfoSerializeError { err });
-                },
-            };
-            if let Err(err) = handle.write_all(sinfo.as_bytes()).await {
-                return Err(CommitError::DataInfoWriteError { path: info_path, err });
-            }
+            let mut handle: tfs::File =
+                tfs::File::create(&info_path).await.map_err(|source| CommitError::DataInfoCreateError { path: info_path.clone(), source })?;
+            let sinfo: String = serde_yaml::to_string(&info).map_err(|source| CommitError::DataInfoSerializeError { source })?;
+            handle.write_all(sinfo.as_bytes()).await.map_err(|source| CommitError::DataInfoWriteError { path: info_path.clone(), source })?;
 
             // Finally, copy the intermediate file to the target
             let source: PathBuf = results_dir.join(path);
             let target: PathBuf = dir.join("data");
             debug!("Copying '{}' to '{}'...", source.display(), target.display());
-            if let Err(err) = copy_dir_recursively_async(source, target).await {
-                return Err(CommitError::DataCopyError { err });
-            }
+            copy_dir_recursively_async(source, target).await.map_err(|source| CommitError::DataCopyError { source })?;
 
             // The dataset has now been promoted
             debug!("Dataset created successfully.");

--- a/brane-cli/src/vm.rs
+++ b/brane-cli/src/vm.rs
@@ -385,16 +385,14 @@ impl OfflineVm {
             };
             match planner.plan(workflow).await {
                 Ok(plan) => Ok(plan),
-                Err(err) => Err(Error::PlanError { err }),
+                Err(source) => Err(Error::PlanError { source }),
             }
         };
         // Unwrap the result (necessary to avoid borrowing conflicts with the lock)
         let plan: Workflow = match plan {
             Ok(plan) => plan,
-            Err(err) => return (self, Err(err)),
+            Err(source) => return (self, Err(source)),
         };
-
-
 
         // Step 2: Execution
         // Now wrap ourselves in a lock so that we can run the internal vm
@@ -409,14 +407,12 @@ impl OfflineVm {
             },
         };
 
-
-
         // Step 3: Result
         // Match the result to potentially error
         let value: FullValue = match result {
             Ok(value) => value,
-            Err(err) => {
-                return (this, Err(Error::ExecError { err }));
+            Err(source) => {
+                return (this, Err(Error::ExecError { source }));
             },
         };
 

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 shlex = "1.1.0"
 tempfile = "3.10.1"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = [] }
 
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-ctl/src/errors.rs
+++ b/brane-ctl/src/errors.rs
@@ -13,7 +13,6 @@
 //
 
 use std::error::Error;
-use std::fmt::{Debug, Display, Formatter, Result as FResult};
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 
@@ -31,666 +30,386 @@ use specifications::version::Version;
 /// Errors that relate to downloading stuff (the subcommand, specifically).
 ///
 /// Note: we box `brane_shr::fs::Error` to avoid the error enum growing too large (see `clippy::result_large_err`).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DownloadError {
     /// Failed to create a new CACHEDIR.TAG
-    CachedirTagCreate { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create CACHEDIR.TAG file '{}'", path.display())]
+    CachedirTagCreate { path: PathBuf, source: std::io::Error },
     /// Failed to write to a new CACHEDIR.TAG
-    CachedirTagWrite { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to CACHEDIR.TAG file '{}'", path.display())]
+    CachedirTagWrite { path: PathBuf, source: std::io::Error },
 
     /// The given directory does not exist.
+    #[error("{} directory '{}' not found", what.capitalize(), path.display())]
     DirNotFound { what: &'static str, path: PathBuf },
     /// The given directory exists but is not a directory.
+    #[error("{} directory '{}' exists but is not a directory", what.capitalize(), path.display())]
     DirNotADir { what: &'static str, path: PathBuf },
     /// Could not create a new directory at the given location.
-    DirCreateError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to create {} directory '{}'", what, path.display())]
+    DirCreateError { what: &'static str, path: PathBuf, source: std::io::Error },
 
     /// Failed to create a temporary directory.
-    TempDirError { err: std::io::Error },
+    #[error("Failed to create a temporary directory")]
+    TempDirError { source: std::io::Error },
     /// Failed to run the actual download command.
-    DownloadError { address: String, path: PathBuf, err: Box<brane_shr::fs::Error> },
+    #[error("Failed to download '{}' to '{}'", address, path.display())]
+    DownloadError { address: String, path: PathBuf, source: Box<brane_shr::fs::Error> },
     /// Failed to extract the given archive.
-    UnarchiveError { tar: PathBuf, target: PathBuf, err: Box<brane_shr::fs::Error> },
+    #[error("Failed to unpack '{}' to '{}'", tar.display(), target.display())]
+    UnarchiveError { tar: PathBuf, target: PathBuf, source: Box<brane_shr::fs::Error> },
     /// Failed to read all entries in a directory.
-    ReadDirError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read directory '{}'", path.display())]
+    ReadDirError { path: PathBuf, source: std::io::Error },
     /// Failed to read a certain entry in a directory.
-    ReadEntryError { path: PathBuf, entry: usize, err: std::io::Error },
+    #[error("Failed to read entry {} in directory '{}'", entry, path.display())]
+    ReadEntryError { path: PathBuf, entry: usize, source: std::io::Error },
     /// Failed to move something.
-    MoveError { source: PathBuf, target: PathBuf, err: Box<brane_shr::fs::Error> },
+    #[error("Failed to move '{}' to '{}'", original.display(), target.display())]
+    MoveError { original: PathBuf, target: PathBuf, source: Box<brane_shr::fs::Error> },
 
     /// Failed to connect to local Docker client.
-    DockerConnectError { err: brane_tsk::docker::Error },
+    #[error("Failed to connect to local Docker daemon")]
+    DockerConnectError { source: brane_tsk::docker::Error },
     /// Failed to pull an image.
-    PullError { name: String, image: String, err: brane_tsk::docker::Error },
+    #[error("Failed to pull '{image}' as '{name}'")]
+    PullError { name: String, image: String, source: brane_tsk::docker::Error },
     /// Failed to save a pulled image.
-    SaveError { name: String, image: String, path: PathBuf, err: brane_tsk::docker::Error },
+    #[error("Failed to save image '{}' to '{}'", name, path.display())]
+    SaveError { name: String, image: String, path: PathBuf, source: brane_tsk::docker::Error },
 }
-impl Display for DownloadError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use self::DownloadError::*;
-        match self {
-            CachedirTagCreate { path, .. } => write!(f, "Failed to create CACHEDIR.TAG file '{}'", path.display()),
-            CachedirTagWrite { path, .. } => write!(f, "Failed to write to CACHEDIR.TAG file '{}'", path.display()),
-
-            DirNotFound { what, path } => write!(f, "{} directory '{}' not found", what.capitalize(), path.display()),
-            DirNotADir { what, path } => write!(f, "{} directory '{}' exists but is not a directory", what.capitalize(), path.display()),
-            DirCreateError { what, path, .. } => write!(f, "Failed to create {} directory '{}'", what, path.display()),
-
-            TempDirError { .. } => write!(f, "Failed to create a temporary directory"),
-            DownloadError { address, path, .. } => write!(f, "Failed to download '{}' to '{}'", address, path.display()),
-            UnarchiveError { tar, target, .. } => write!(f, "Failed to unpack '{}' to '{}'", tar.display(), target.display()),
-            ReadDirError { path, .. } => write!(f, "Failed to read directory '{}'", path.display()),
-            ReadEntryError { path, entry, .. } => write!(f, "Failed to read entry {} in directory '{}'", entry, path.display()),
-            MoveError { source, target, .. } => write!(f, "Failed to move '{}' to '{}'", source.display(), target.display()),
-
-            DockerConnectError { .. } => write!(f, "Failed to connect to local Docker daemon"),
-            PullError { name, image, .. } => write!(f, "Failed to pull '{image}' as '{name}'"),
-            SaveError { name, path, .. } => write!(f, "Failed to save image '{}' to '{}'", name, path.display()),
-        }
-    }
-}
-impl Error for DownloadError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use self::DownloadError::*;
-        match self {
-            CachedirTagCreate { err, .. } => Some(err),
-            CachedirTagWrite { err, .. } => Some(err),
-
-            DirNotFound { .. } => None,
-            DirNotADir { .. } => None,
-            DirCreateError { err, .. } => Some(err),
-
-            TempDirError { err } => Some(err),
-            DownloadError { err, .. } => Some(err),
-            UnarchiveError { err, .. } => Some(err),
-            ReadDirError { err, .. } => Some(err),
-            ReadEntryError { err, .. } => Some(err),
-            MoveError { err, .. } => Some(err),
-
-            DockerConnectError { err } => Some(err),
-            PullError { err, .. } => Some(err),
-            SaveError { err, .. } => Some(err),
-        }
-    }
-}
-
 
 
 /// Errors that relate to generating files.
 ///
 /// Note: we box `brane_shr::fs::Error` to avoid the error enum growing too large (see `clippy::result_large_err`).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum GenerateError {
     /// Directory not found.
+    #[error("Directory '{}' not found", path.display())]
     DirNotFound { path: PathBuf },
     /// Directory found but not as a directory
+    #[error("Directory '{}' exists but not as a directory", path.display())]
     DirNotADir { path: PathBuf },
     /// Failed to create a directory.
-    DirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create directory '{}'", path.display())]
+    DirCreateError { path: PathBuf, source: std::io::Error },
 
     /// Failed to canonicalize the given path.
-    CanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to canonicalize path '{}'", path.display())]
+    CanonicalizeError { path: PathBuf, source: std::io::Error },
 
     /// The given file is not a file.
+    #[error("File '{}' exists but not as a file", path.display())]
     FileNotAFile { path: PathBuf },
     /// Failed to write to the output file.
-    FileWriteError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to {} file '{}'", what, path.display())]
+    FileWriteError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to serialize & write to the output file.
-    FileSerializeError { what: &'static str, path: PathBuf, err: serde_json::Error },
+    #[error("Failed to write JSON to {} file '{}'", what, path.display())]
+    FileSerializeError { what: &'static str, path: PathBuf, source: serde_json::Error },
     /// Failed to deserialize & read an input file.
-    FileDeserializeError { what: &'static str, path: PathBuf, err: serde_json::Error },
+    #[error("Failed to read JSON from {} file '{}'", what, path.display())]
+    FileDeserializeError { what: &'static str, path: PathBuf, source: serde_json::Error },
     /// Failed to extract a file.
-    ExtractError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to extract embedded {}-binary to '{}'", what, path.display())]
+    ExtractError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to set a file to executable.
-    ExecutableError { err: Box<brane_shr::fs::Error> },
+    #[error("Failed to make file executable")]
+    ExecutableError { source: Box<brane_shr::fs::Error> },
 
     /// Failed to get a file handle's metadata.
-    FileMetadataError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to get metadata of {} file '{}'", what, path.display())]
+    FileMetadataError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to set the permissions of a file.
-    FilePermissionsError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to set permissions of {} file '{}'", what, path.display())]
+    FilePermissionsError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// The downloaded file did not have the required checksum.
+    #[error("File '{}' had unexpected checksum (might indicate the download is no longer valid)", path.display())]
     FileChecksumError { path: PathBuf, expected: String, got: String },
     /// Failed to serialize a config file.
-    ConfigSerializeError { err: serde_json::Error },
+    #[error("Failed to serialize config")]
+    ConfigSerializeError { source: serde_json::Error },
     /// Failed to spawn a new job.
-    SpawnError { cmd: Command, err: std::io::Error },
+    #[error("Failed to run command '{cmd:?}'")]
+    SpawnError { cmd: Command, source: std::io::Error },
     /// A spawned fob failed.
-    SpawnFailure { cmd: Command, status: ExitStatus, err: String },
+    #[error("Command '{cmd:?}' failed{code}\n\nstderr:\n{stderr}\n\n", code = if let Some(code) = status.code() { format!(" with exit code {code}") } else { String::new() })]
+    SpawnFailure { cmd: Command, status: ExitStatus, stderr: String },
     /// Assertion that the CA certificate exists failed.
+    #[error("Certificate authority's certificate '{}' not found", path.display())]
     CaCertNotFound { path: PathBuf },
     /// Assertion that the CA certificate is a file failed.
+    #[error("Certificate authority's certificate '{}' exists but is not a file", path.display())]
     CaCertNotAFile { path: PathBuf },
     /// Assertion that the CA key exists failed.
+    #[error("Certificate authority's private key '{}' not found", path.display())]
     CaKeyNotFound { path: PathBuf },
     /// Assertion that the CA key is a file failed.
+    #[error("Certificate authority's private key '{}' exists but is not a file", path.display())]
     CaKeyNotAFile { path: PathBuf },
     /// Failed to open a new file.
-    FileOpenError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to open {} file '{}'", what, path.display())]
+    FileOpenError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to copy one file into another.
-    CopyError { source: PathBuf, target: PathBuf, err: std::io::Error },
+    #[error("Failed to write '{}' to '{}'", original.display(), target.display())]
+    CopyError { original: PathBuf, target: PathBuf, source: std::io::Error },
 
     /// Failed to create a new file.
-    FileCreateError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to create new {} file '{what}'", path.display())]
+    FileCreateError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to write the header to the new file.
-    FileHeaderWriteError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to write header to {} file '{what}'", path.display())]
+    FileHeaderWriteError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to write the main body to the new file.
-    FileBodyWriteError { what: &'static str, path: PathBuf, err: brane_cfg::info::YamlError },
+    #[error("Failed to write body to {what} file")]
+    FileBodyWriteError { what: &'static str, path: PathBuf, source: brane_cfg::info::YamlError },
 
     /// The given location is unknown.
+    #[error("Unknown location '{loc}' (did you forget to specify it in the LOCATIONS argument?)")]
     UnknownLocation { loc: String },
 
     /// Failed to create a temporary directory.
-    TempDirError { err: std::io::Error },
+    #[error("Failed to create temporary directory in system temp folder")]
+    TempDirError { source: std::io::Error },
     /// Failed to download the repo
-    RepoDownloadError { repo: String, target: PathBuf, err: brane_shr::fs::Error },
+    #[error("Failed to download repository archive '{}' to '{}'", repo, target.display())]
+    RepoDownloadError { repo: String, target: PathBuf, source: brane_shr::fs::Error },
     /// Failed to unpack the downloaded repo archive
-    RepoUnpackError { tar: PathBuf, target: PathBuf, err: brane_shr::fs::Error },
+    #[error("Failed to unpack repository archive '{}' to '{}'", tar.display(), target.display())]
+    RepoUnpackError { tar: PathBuf, target: PathBuf, source: brane_shr::fs::Error },
     /// Failed to recurse into the downloaded repo archive's only folder
-    RepoRecurseError { target: PathBuf, err: brane_shr::fs::Error },
+    #[error("Failed to recurse into only directory of unpacked repository archive '{}'", target.display())]
+    RepoRecurseError { target: PathBuf, source: brane_shr::fs::Error },
     /// Failed to find the migrations in the repo.
-    MigrationsRetrieve { path: PathBuf, err: diesel_migrations::MigrationError },
+    #[error("Failed to find Diesel migrations in '{}'", path.display())]
+    MigrationsRetrieve { path: PathBuf, source: diesel_migrations::MigrationError },
     /// Failed to connect to the database file.
-    DatabaseConnect { path: PathBuf, err: diesel::ConnectionError },
+    #[error("Failed to connect to SQLite database file '{}'", path.display())]
+    DatabaseConnect { path: PathBuf, source: diesel::ConnectionError },
     /// Failed to apply a set of mitigations.
-    MigrationsApply { path: PathBuf, err: Box<dyn 'static + Error> },
+    #[error("Failed to apply migrations to SQLite database file '{}'", path.display())]
+    MigrationsApply { path: PathBuf, source: Box<dyn 'static + Error> },
 
     /// A particular combination of policy secret settings was not supported.
+    #[error("Policy key algorithm {key_alg} is unsupported")]
     UnsupportedKeyAlgorithm { key_alg: KeyAlgorithm },
     /// Failed to generate a new policy token.
-    TokenGenerate { err: specifications::policy::Error },
+    #[error("Failed to generate new policy token")]
+    TokenGenerate { source: specifications::policy::Error },
 }
-impl Display for GenerateError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use GenerateError::*;
-        match self {
-            DirNotFound { path } => write!(f, "Directory '{}' not found", path.display()),
-            DirNotADir { path } => write!(f, "Directory '{}' exists but not as a directory", path.display()),
-            DirCreateError { path, .. } => write!(f, "Failed to create directory '{}'", path.display()),
-
-            CanonicalizeError { path, .. } => write!(f, "Failed to canonicalize path '{}'", path.display()),
-
-            FileNotAFile { path } => write!(f, "File '{}' exists but not as a file", path.display()),
-            FileWriteError { what, path, .. } => write!(f, "Failed to write to {} file '{}'", what, path.display()),
-            FileSerializeError { what, path, .. } => write!(f, "Failed to write JSON to {} file '{}'", what, path.display()),
-            FileDeserializeError { what, path, .. } => write!(f, "Failed to read JSON from {} file '{}'", what, path.display()),
-            ExtractError { what, path, .. } => write!(f, "Failed to extract embedded {}-binary to '{}'", what, path.display()),
-            ExecutableError { .. } => write!(f, "Failed to make file executable"),
-
-            FileMetadataError { what, path, .. } => write!(f, "Failed to get metadata of {} file '{}'", what, path.display()),
-            FilePermissionsError { what, path, .. } => write!(f, "Failed to set permissions of {} file '{}'", what, path.display()),
-            FileChecksumError { path, .. } => {
-                write!(f, "File '{}' had unexpected checksum (might indicate the download is no longer valid)", path.display())
-            },
-            ConfigSerializeError { .. } => write!(f, "Failed to serialize config"),
-            SpawnError { cmd, .. } => write!(f, "Failed to run command '{cmd:?}'"),
-            SpawnFailure { cmd, status, err } => write!(
-                f,
-                "Command '{:?}' failed{}\n\nstderr:\n{}\n\n",
-                cmd,
-                if let Some(code) = status.code() { format!(" with exit code {code}") } else { String::new() },
-                err
-            ),
-            CaCertNotFound { path } => write!(f, "Certificate authority's certificate '{}' not found", path.display()),
-            CaCertNotAFile { path } => write!(f, "Certificate authority's certificate '{}' exists but is not a file", path.display()),
-            CaKeyNotFound { path } => write!(f, "Certificate authority's private key '{}' not found", path.display()),
-            CaKeyNotAFile { path } => write!(f, "Certificate authority's private key '{}' exists but is not a file", path.display()),
-            FileOpenError { what, path, .. } => write!(f, "Failed to open {} file '{}'", what, path.display()),
-            CopyError { source, target, .. } => write!(f, "Failed to write '{}' to '{}'", source.display(), target.display()),
-
-            FileCreateError { what, path, .. } => write!(f, "Failed to create new {} file '{what}'", path.display()),
-            FileHeaderWriteError { what, path, .. } => write!(f, "Failed to write header to {} file '{what}'", path.display()),
-            FileBodyWriteError { what, .. } => write!(f, "Failed to write body to {what} file"),
-
-            UnknownLocation { loc } => write!(f, "Unknown location '{loc}' (did you forget to specify it in the LOCATIONS argument?)"),
-
-            TempDirError { .. } => write!(f, "Failed to create temporary directory in system temp folder"),
-            RepoDownloadError { repo, target, .. } => write!(f, "Failed to download repository archive '{}' to '{}'", repo, target.display()),
-            RepoUnpackError { tar, target, .. } => write!(f, "Failed to unpack repository archive '{}' to '{}'", tar.display(), target.display()),
-            RepoRecurseError { target, .. } => {
-                write!(f, "Failed to recurse into only directory of unpacked repository archive '{}'", target.display())
-            },
-            MigrationsRetrieve { path, .. } => write!(f, "Failed to find Diesel migrations in '{}'", path.display()),
-            DatabaseConnect { path, .. } => write!(f, "Failed to connect to SQLite database file '{}'", path.display()),
-            MigrationsApply { path, .. } => write!(f, "Failed to apply migrations to SQLite database file '{}'", path.display()),
-
-            UnsupportedKeyAlgorithm { key_alg } => {
-                write!(f, "Policy key algorithm {key_alg} is unsupported")
-            },
-            TokenGenerate { .. } => write!(f, "Failed to generate new policy token"),
-        }
-    }
-}
-impl Error for GenerateError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use GenerateError::*;
-        match self {
-            DirNotFound { .. } => None,
-            DirNotADir { .. } => None,
-            DirCreateError { err, .. } => Some(err),
-
-            CanonicalizeError { err, .. } => Some(err),
-
-            FileNotAFile { .. } => None,
-            FileWriteError { err, .. } => Some(err),
-            FileSerializeError { err, .. } => Some(err),
-            FileDeserializeError { err, .. } => Some(err),
-            ExtractError { err, .. } => Some(err),
-            ExecutableError { err } => Some(err),
-
-            FileMetadataError { err, .. } => Some(err),
-            FilePermissionsError { err, .. } => Some(err),
-            FileChecksumError { .. } => None,
-            ConfigSerializeError { err } => Some(err),
-            SpawnError { err, .. } => Some(err),
-            SpawnFailure { .. } => None,
-            CaCertNotFound { .. } => None,
-            CaCertNotAFile { .. } => None,
-            CaKeyNotFound { .. } => None,
-            CaKeyNotAFile { .. } => None,
-            FileOpenError { err, .. } => Some(err),
-            CopyError { err, .. } => Some(err),
-
-            FileCreateError { err, .. } => Some(err),
-            FileHeaderWriteError { err, .. } => Some(err),
-            FileBodyWriteError { err, .. } => Some(err),
-
-            UnknownLocation { .. } => None,
-
-            TempDirError { err } => Some(err),
-            RepoDownloadError { err, .. } => Some(err),
-            RepoUnpackError { err, .. } => Some(err),
-            RepoRecurseError { err, .. } => Some(err),
-            MigrationsRetrieve { err, .. } => Some(err),
-            DatabaseConnect { err, .. } => Some(err),
-            MigrationsApply { err, .. } => Some(&**err),
-
-            UnsupportedKeyAlgorithm { .. } => None,
-            TokenGenerate { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Errors that relate to managing the lifetime of the node.
 ///
 /// Note: we've boxed `Image` and `ImageSource` to reduce the size of the error (and avoid running into `clippy::result_large_err`).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LifetimeError {
     /// Failed to canonicalize the given path.
-    CanonicalizeError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to canonicalize path '{}'", path.display())]
+    CanonicalizeError { path: PathBuf, source: std::io::Error },
     /// Failed to resolve the executable to a list of shell arguments.
+    #[error("Failed to parse '{raw}' as a valid string of bash-arguments")]
     ExeParseError { raw: String },
 
     /// Failed to verify the given Docker Compose file exists.
+    #[error("Docker Compose file '{}' not found", path.display())]
     DockerComposeNotFound { path: PathBuf },
     /// Failed to verify the given Docker Compose file is a file.
+    #[error("Docker Compose file '{}' exists but is not a file", path.display())]
     DockerComposeNotAFile { path: PathBuf },
     /// Relied on a build-in for a Docker Compose version that is not the default one.
+    #[error("No baked-in {kind} Docker Compose for Brane version v{version} exists (give it yourself using '--file')")]
     DockerComposeNotBakedIn { kind: NodeKind, version: Version },
     /// Failed to open a new Docker Compose file.
-    DockerComposeCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create Docker Compose file '{}'", path.display())]
+    DockerComposeCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to a Docker Compose file.
-    DockerComposeWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to Docker Compose file '{}'", path.display())]
+    DockerComposeWriteError { path: PathBuf, source: std::io::Error },
 
     /// Failed to touch the audit log into existance.
-    AuditLogCreate { path: PathBuf, err: std::io::Error },
+    #[error("Failed to touch audit log '{}' into existance", path.display())]
+    AuditLogCreate { path: PathBuf, source: std::io::Error },
 
     /// Failed to read the `proxy.yml` file.
-    ProxyReadError { err: brane_cfg::info::YamlError },
+    #[error("Failed to read proxy config file")]
+    ProxyReadError { source: brane_cfg::info::YamlError },
     /// Failed to open the extra hosts file.
-    HostsFileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create extra hosts file '{}'", path.display())]
+    HostsFileCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the extra hosts file.
-    HostsFileWriteError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to write to extra hosts file '{}'", path.display())]
+    HostsFileWriteError { path: PathBuf, source: serde_yaml::Error },
 
     /// Failed to get the digest of the given image file.
-    ImageDigestError { path: PathBuf, err: brane_tsk::docker::Error },
+    #[error("Failed to get digest of image {}", style(path.display()).bold())]
+    ImageDigestError { path: PathBuf, source: brane_tsk::docker::Error },
     /// Failed to load/import the given image.
-    ImageLoadError { image: Box<Image>, source: Box<ImageSource>, err: brane_tsk::docker::Error },
+    #[error("Failed to load image {} from '{}'", style(image).bold(), style(source).bold())]
+    ImageLoadError { image: Box<Image>, image_source: Box<ImageSource>, source: brane_tsk::docker::Error },
 
     /// The user gave us a proxy service definition, but not a proxy file path.
+    #[error(
+        "A proxy service specification is given, but not a path to a 'proxy.yml' file. Specify both if you want to host a proxy service in this \
+         node, or none if you want to use an external one."
+    )]
     MissingProxyPath,
     /// The user gave use a proxy file path, but not a proxy service definition.
+    #[error(
+        "A path to a 'proxy.yml' file is given, but not a proxy service specification. Specify both if you want to host a proxy service in this \
+         node, or none if you want to use an external one."
+    )]
     MissingProxyService,
 
     /// Failed to load the given node config file.
-    NodeConfigLoadError { err: brane_cfg::info::YamlError },
+    #[error("Failed to load node.yml file")]
+    NodeConfigLoadError { source: brane_cfg::info::YamlError },
     /// Failed to connect to the local Docker daemon.
-    DockerConnectError { err: brane_tsk::errors::DockerError },
+    #[error("Failed to connect to local Docker socket")]
+    DockerConnectError { source: brane_tsk::errors::DockerError },
     /// The given start command (got) did not match the one in the `node.yml` file (expected).
+    #[error("Got command to start {} node, but 'node.yml' defined a {} node", got.variant(), expected.variant())]
     UnmatchedNodeKind { got: NodeKind, expected: NodeKind },
 
     /// Failed to launch the given job.
-    JobLaunchError { command: Command, err: std::io::Error },
+    #[error("Failed to launch command '{command:?}'")]
+    JobLaunchError { command: Command, source: std::io::Error },
     /// The given job failed.
+    #[error("Command '{}' failed with exit code {} (see output above)", style(format!("{command:?}")).bold(), style(status.code().map(|c| c.to_string()).unwrap_or_else(|| "non-zero".into())).bold())]
     JobFailure { command: Command, status: ExitStatus },
 }
-impl Display for LifetimeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use LifetimeError::*;
-        match self {
-            CanonicalizeError { path, .. } => write!(f, "Failed to canonicalize path '{}'", path.display()),
-            ExeParseError { raw } => write!(f, "Failed to parse '{raw}' as a valid string of bash-arguments"),
-
-            DockerComposeNotFound { path } => write!(f, "Docker Compose file '{}' not found", path.display()),
-            DockerComposeNotAFile { path } => write!(f, "Docker Compose file '{}' exists but is not a file", path.display()),
-            DockerComposeNotBakedIn { kind, version } => {
-                write!(f, "No baked-in {kind} Docker Compose for Brane version v{version} exists (give it yourself using '--file')")
-            },
-            DockerComposeCreateError { path, .. } => write!(f, "Failed to create Docker Compose file '{}'", path.display()),
-            DockerComposeWriteError { path, .. } => write!(f, "Failed to write to Docker Compose file '{}'", path.display()),
-
-            AuditLogCreate { path, .. } => write!(f, "Failed to touch audit log '{}' into existance", path.display()),
-
-            ProxyReadError { .. } => write!(f, "Failed to read proxy config file"),
-            HostsFileCreateError { path, .. } => write!(f, "Failed to create extra hosts file '{}'", path.display()),
-            HostsFileWriteError { path, .. } => write!(f, "Failed to write to extra hosts file '{}'", path.display()),
-
-            ImageDigestError { path, .. } => write!(f, "Failed to get digest of image {}", style(path.display()).bold()),
-            ImageLoadError { image, source, .. } => {
-                write!(f, "Failed to load image {} from '{}'", style(image).bold(), style(source).bold())
-            },
-
-            MissingProxyPath => write!(
-                f,
-                "A proxy service specification is given, but not a path to a 'proxy.yml' file. Specify both if you want to host a proxy service in \
-                 this node, or none if you want to use an external one."
-            ),
-            MissingProxyService => write!(
-                f,
-                "A path to a 'proxy.yml' file is given, but not a proxy service specification. Specify both if you want to host a proxy service in \
-                 this node, or none if you want to use an external one."
-            ),
-
-            NodeConfigLoadError { .. } => write!(f, "Failed to load node.yml file"),
-            DockerConnectError { .. } => write!(f, "Failed to connect to local Docker socket"),
-            UnmatchedNodeKind { got, expected } => {
-                write!(f, "Got command to start {} node, but 'node.yml' defined a {} node", got.variant(), expected.variant())
-            },
-
-            JobLaunchError { command, .. } => write!(f, "Failed to launch command '{command:?}'"),
-            JobFailure { command, status } => write!(
-                f,
-                "Command '{}' failed with exit code {} (see output above)",
-                style(format!("{command:?}")).bold(),
-                style(status.code().map(|c| c.to_string()).unwrap_or_else(|| "non-zero".into())).bold()
-            ),
-        }
-    }
-}
-impl Error for LifetimeError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use LifetimeError::*;
-        match self {
-            CanonicalizeError { err, .. } => Some(err),
-            ExeParseError { .. } => None,
-
-            DockerComposeNotFound { .. } => None,
-            DockerComposeNotAFile { .. } => None,
-            DockerComposeNotBakedIn { .. } => None,
-            DockerComposeCreateError { err, .. } => Some(err),
-            DockerComposeWriteError { err, .. } => Some(err),
-
-            AuditLogCreate { err, .. } => Some(err),
-
-            ProxyReadError { err } => Some(err),
-            HostsFileCreateError { err, .. } => Some(err),
-            HostsFileWriteError { err, .. } => Some(err),
-
-            ImageDigestError { err, .. } => Some(err),
-            ImageLoadError { err, .. } => Some(err),
-
-            MissingProxyPath => None,
-            MissingProxyService => None,
-
-            NodeConfigLoadError { err } => Some(err),
-            DockerConnectError { err } => Some(err),
-            UnmatchedNodeKind { .. } => None,
-
-            JobLaunchError { err, .. } => Some(err),
-            JobFailure { .. } => None,
-        }
-    }
-}
-
-
 
 /// Errors that relate to package subcommands.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PackagesError {
     /// Failed to load the given node config file.
-    NodeConfigLoadError { err: brane_cfg::info::YamlError },
+    #[error("Failed to load node.yml file")]
+    NodeConfigLoadError { source: brane_cfg::info::YamlError },
     /// The given node type is not supported for this operation.
-    ///
     /// The `what` should fill in the \<WHAT\> in: "Cannot \<WHAT\> on a ... node"
+    #[error("Cannot {what} on a {} node", kind.variant())]
     UnsupportedNode { what: &'static str, kind: NodeKind },
     /// The given file is not a file.
+    #[error("Given image path '{}' exists but is not a file", path.display())]
     FileNotAFile { path: PathBuf },
     /// Failed to parse the given `NAME[:VERSION]` pair.
-    IllegalNameVersionPair { raw: String, err: specifications::version::ParseError },
+    #[error("Failed to parse given image name[:version] pair '{raw}'")]
+    IllegalNameVersionPair { raw: String, source: specifications::version::ParseError },
     /// Failed to read the given directory
-    DirReadError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to read {} directory '{}'", what, path.display())]
+    DirReadError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to read an entry in the given directory
-    DirEntryReadError { what: &'static str, entry: usize, path: PathBuf, err: std::io::Error },
+    #[error("Failed to read entry {} in {} directory '{}'", entry, what, path.display())]
+    DirEntryReadError { what: &'static str, entry: usize, path: PathBuf, source: std::io::Error },
     /// The given `NAME[:VERSION]` pair did not have a candidate.
+    #[error("No image for package '{}', version {} found in '{}'", name, version, path.display())]
     UnknownImage { path: PathBuf, name: String, version: Version },
     /// Failed to hash the found image file.
-    HashError { err: brane_tsk::docker::Error },
+    #[error("Failed to hash image")]
+    HashError { source: brane_tsk::docker::Error },
 }
-impl Display for PackagesError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use PackagesError::*;
-        match self {
-            NodeConfigLoadError { err } => write!(f, "Failed to load node.yml file: {err}"),
-            UnsupportedNode { what, kind } => write!(f, "Cannot {what} on a {} node", kind.variant()),
-            FileNotAFile { path } => write!(f, "Given image path '{}' exists but is not a file", path.display()),
-            IllegalNameVersionPair { raw, err } => write!(f, "Failed to parse given image name[:version] pair '{raw}': {err}"),
-            DirReadError { what, path, err } => write!(f, "Failed to read {} directory '{}': {}", what, path.display(), err),
-            DirEntryReadError { what, entry, path, err } => {
-                write!(f, "Failed to read entry {} in {} directory '{}': {}", entry, what, path.display(), err)
-            },
-            UnknownImage { path, name, version } => write!(f, "No image for package '{}', version {} found in '{}'", name, version, path.display()),
-            HashError { err } => write!(f, "Failed to hash image: {err}"),
-        }
-    }
-}
-impl Error for PackagesError {}
-
-
 
 /// Errors that relate to unpacking files.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum UnpackError {
     /// Failed to get the NodeConfig file.
-    NodeConfigError { err: brane_cfg::info::YamlError },
+    #[error("Failed to read node config file (specify a kind manually using '--kind')")]
+    NodeConfigError { source: brane_cfg::info::YamlError },
     /// Failed to write the given file.
-    FileWriteError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to write {} file to '{}'", what, path.display())]
+    FileWriteError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to create the target directory.
-    TargetDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create target directory '{}'", path.display())]
+    TargetDirCreateError { path: PathBuf, source: std::io::Error },
     /// The target directory was not found.
+    #[error("Target directory '{}' not found (you can create it by re-running this command with '-f')", path.display())]
     TargetDirNotFound { path: PathBuf },
     /// The target directory was not a directory.
+    #[error("Target directory '{}' exists but is not a directory", path.display())]
     TargetDirNotADir { path: PathBuf },
 }
-impl Display for UnpackError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use UnpackError::*;
-        match self {
-            NodeConfigError { err } => write!(f, "Failed to read node config file: {err} (specify a kind manually using '--kind')"),
-            FileWriteError { what, path, err } => write!(f, "Failed to write {} file to '{}': {}", what, path.display(), err),
-            TargetDirCreateError { path, err } => write!(f, "Failed to create target directory '{}': {}", path.display(), err),
-            TargetDirNotFound { path } => {
-                write!(f, "Target directory '{}' not found (you can create it by re-running this command with '-f')", path.display())
-            },
-            TargetDirNotADir { path } => write!(f, "Target directory '{}' exists but is not a directory", path.display()),
-        }
-    }
-}
-impl Error for UnpackError {}
-
-
 
 /// Errors that relate to parsing Docker client version numbers.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DockerClientVersionParseError {
     /// Missing a dot in the version number
+    #[error("Missing '.' in Docket client version number '{raw}'")]
     MissingDot { raw: String },
     /// The given major version was not a valid usize
-    IllegalMajorNumber { raw: String, err: std::num::ParseIntError },
+    #[error("'{raw}' is not a valid Docket client version major number")]
+    IllegalMajorNumber { raw: String, source: std::num::ParseIntError },
     /// The given major version was not a valid usize
-    IllegalMinorNumber { raw: String, err: std::num::ParseIntError },
+    #[error("'{raw}' is not a valid Docket client version minor number")]
+    IllegalMinorNumber { raw: String, source: std::num::ParseIntError },
 }
-impl Display for DockerClientVersionParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DockerClientVersionParseError::*;
-        match self {
-            MissingDot { raw } => write!(f, "Missing '.' in Docket client version number '{raw}'"),
-            IllegalMajorNumber { raw, err } => write!(f, "'{raw}' is not a valid Docket client version major number: {err}"),
-            IllegalMinorNumber { raw, err } => write!(f, "'{raw}' is not a valid Docket client version minor number: {err}"),
-        }
-    }
-}
-impl Error for DockerClientVersionParseError {}
-
-
 
 /// Errors that relate to parsing InclusiveRanges.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum InclusiveRangeParseError {
     /// Did not find the separating dash
+    #[error("Missing '-' in range '{raw}'")]
     MissingDash { raw: String },
     /// Failed to parse one of the numbers
-    NumberParseError { what: &'static str, raw: String, err: Box<dyn Send + Sync + Error> },
+    #[error("Failed to parse '{raw}' as a valid {what}")]
+    NumberParseError { what: &'static str, raw: String, source: Box<dyn Send + Sync + Error> },
     /// The first number is not equal to or higher than the second one
+    #[error("Start index '{start}' is larger than end index '{end}'")]
     StartLargerThanEnd { start: String, end: String },
 }
-impl Display for InclusiveRangeParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use InclusiveRangeParseError::*;
-        match self {
-            MissingDash { raw } => write!(f, "Missing '-' in range '{raw}'"),
-            NumberParseError { what, raw, err } => write!(f, "Failed to parse '{raw}' as a valid {what}: {err}"),
-            StartLargerThanEnd { start, end } => write!(f, "Start index '{start}' is larger than end index '{end}'"),
-        }
-    }
-}
-impl Error for InclusiveRangeParseError {}
-
-
 
 /// Errors that relate to parsing pairs of things.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PairParseError {
     /// Missing an equals in the pair.
+    #[error("Missing '{separator}' in location pair '{raw}'")]
     MissingSeparator { separator: char, raw: String },
     /// Failed to parse the given something as a certain other thing
-    IllegalSomething { what: &'static str, raw: String, err: Box<dyn Send + Sync + Error> },
+    #[error("Failed to parse '{raw}' as a {what}")]
+    IllegalSomething { what: &'static str, raw: String, source: Box<dyn Send + Sync + Error> },
 }
-impl Display for PairParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use PairParseError::*;
-        match self {
-            MissingSeparator { separator, raw } => write!(f, "Missing '{separator}' in location pair '{raw}'"),
-            IllegalSomething { what, raw, err } => write!(f, "Failed to parse '{raw}' as a {what}: {err}"),
-        }
-    }
-}
-impl Error for PairParseError {}
-
-
 
 /// Errors that relate to parsing [`PolicyInputLanguage`](crate::spec::PolicyInputLanguage)s.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PolicyInputLanguageParseError {
     /// The given identifier was not recognized.
+    #[error("Unknown policy input language '{raw}' (options are 'eflint' or 'eflint-json')")]
     Unknown { raw: String },
 }
-impl Display for PolicyInputLanguageParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use PolicyInputLanguageParseError::*;
-        match self {
-            Unknown { raw } => write!(f, "Unknown policy input language '{raw}' (options are 'eflint' or 'eflint-json')"),
-        }
-    }
-}
-impl Error for PolicyInputLanguageParseError {}
-
-
 
 /// Errors that relate to parsing architecture iDs.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ArchParseError {
     /// Failed to spawn the `uname -m` command.
-    SpawnError { command: Command, err: std::io::Error },
+    #[error("Failed to run '{command:?}'")]
+    SpawnError { command: Command, source: std::io::Error },
     /// The `uname -m` command returned a non-zero exit code.
-    SpawnFailure { command: Command, status: ExitStatus, err: String },
+    #[error("Command '{command:?}' failed with exit code {code}\n\nstderr:\n{stderr}\n\n", code = status.code().unwrap_or(-1))]
+    SpawnFailure { command: Command, status: ExitStatus, stderr: String },
     /// It's an unknown architecture.
+    #[error("Unknown architecture '{raw}'")]
     UnknownArch { raw: String },
 }
-impl Display for ArchParseError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ArchParseError::*;
-        match self {
-            SpawnError { command, err } => write!(f, "Failed to run '{command:?}': {err}"),
-            SpawnFailure { command, status, err } => {
-                write!(f, "Command '{:?}' failed with exit code {}\n\nstderr:\n{}\n\n", command, status.code().unwrap_or(-1), err)
-            },
-            UnknownArch { raw } => write!(f, "Unknown architecture '{raw}'"),
-        }
-    }
-}
-impl Error for ArchParseError {}
-
-
 
 /// Errors that relate to parsing JWT signing algorithm IDs.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum JwtAlgorithmParseError {
     /// Unknown identifier given.
+    #[error("Unknown JWT algorithm '{raw}' (options are: 'HS256')")]
     Unknown { raw: String },
 }
-impl Display for JwtAlgorithmParseError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use JwtAlgorithmParseError::*;
-        match self {
-            Unknown { raw } => write!(f, "Unknown JWT algorithm '{raw}' (options are: 'HS256')"),
-        }
-    }
-}
-impl Error for JwtAlgorithmParseError {}
 
 /// Errors that relate to parsing key type IDs.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum KeyTypeParseError {
     /// Unknown identifier given.
+    #[error("Unknown key type '{raw}' (options are: 'oct')")]
     Unknown { raw: String },
 }
-impl Display for KeyTypeParseError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use KeyTypeParseError::*;
-        match self {
-            Unknown { raw } => write!(f, "Unknown key type '{raw}' (options are: 'oct')"),
-        }
-    }
-}
-impl Error for KeyTypeParseError {}
 
 /// Errors that relate to parsing key usage IDs.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum KeyUsageParseError {
     /// Unknown identifier given.
+    #[error("Unknown key usage '{raw}' (options are: 'sig')")]
     Unknown { raw: String },
 }
-impl Display for KeyUsageParseError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use KeyUsageParseError::*;
-        match self {
-            Unknown { raw } => write!(f, "Unknown key usage '{raw}' (options are: 'sig')"),
-        }
-    }
-}
-impl Error for KeyUsageParseError {}

--- a/brane-ctl/src/spec.rs
+++ b/brane-ctl/src/spec.rs
@@ -168,15 +168,15 @@ where
         let send: &str = &s[dpos + 1..];
 
         // Parse them
-        let start: T = T::from_str(sstart).map_err(|err| InclusiveRangeParseError::NumberParseError {
-            what: std::any::type_name::<T>(),
-            raw:  sstart.into(),
-            err:  Box::new(err),
+        let start: T = T::from_str(sstart).map_err(|source| InclusiveRangeParseError::NumberParseError {
+            what:   std::any::type_name::<T>(),
+            raw:    sstart.into(),
+            source: Box::new(source),
         })?;
-        let end: T = T::from_str(send).map_err(|err| InclusiveRangeParseError::NumberParseError {
-            what: std::any::type_name::<T>(),
-            raw:  send.into(),
-            err:  Box::new(err),
+        let end: T = T::from_str(send).map_err(|source| InclusiveRangeParseError::NumberParseError {
+            what:   std::any::type_name::<T>(),
+            raw:    send.into(),
+            source: Box::new(source),
         })?;
 
         // Assert the order is correct
@@ -223,15 +223,15 @@ where
         let svalue: &str = &s[sep_pos + 1..];
 
         // Attempt to parse the something as the key
-        let key: K = K::from_str(skey).map_err(|err| PairParseError::IllegalSomething {
-            what: std::any::type_name::<K>(),
-            raw:  skey.into(),
-            err:  Box::new(err),
+        let key: K = K::from_str(skey).map_err(|source| PairParseError::IllegalSomething {
+            what:   std::any::type_name::<K>(),
+            raw:    skey.into(),
+            source: Box::new(source),
         })?;
-        let value: V = V::from_str(svalue).map_err(|err| PairParseError::IllegalSomething {
-            what: std::any::type_name::<V>(),
-            raw:  svalue.into(),
-            err:  Box::new(err),
+        let value: V = V::from_str(svalue).map_err(|source| PairParseError::IllegalSomething {
+            what:   std::any::type_name::<V>(),
+            raw:    svalue.into(),
+            source: Box::new(source),
         })?;
 
         // OK, return ourselves

--- a/brane-drv/Cargo.toml
+++ b/brane-drv/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4.22"
 reqwest = { version = "0.12.0" }
 serde_json = "1.0.120"
 serde_json_any_key = "2.0.0"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-stream = "0.1.6"
 tonic = "0.12.0"

--- a/brane-drv/src/errors.rs
+++ b/brane-drv/src/errors.rs
@@ -12,54 +12,26 @@
 //!   Contains errors used within the brane-drv package only.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::path::PathBuf;
-
 
 /***** ERRORS *****/
 /// Defines errors that relate to the RemoteVm.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RemoteVmError {
     /// Failed to plan a workflow.
-    PlanError { err: brane_tsk::errors::PlanError },
+    #[error("Failed to plan workflow")]
+    PlanError { source: brane_tsk::errors::PlanError },
     /// Failed to run a workflow.
-    ExecError { err: brane_exe::Error },
+    #[error("Failed to execute workflow")]
+    ExecError { source: brane_exe::Error },
 
     /// The given node config was not for this type of node.
+    #[error("Illegal node config kind in node config '{}'; expected Central, got {}", path.display(), got)]
     IllegalNodeConfig { path: PathBuf, got: String },
     /// Failed to load the given infra file.
-    InfraFileLoad { path: PathBuf, err: brane_cfg::info::YamlError },
+    #[error("Failed to load infra file '{}'", path.display())]
+    InfraFileLoad { path: PathBuf, source: brane_cfg::info::YamlError },
     /// Failed to load the given node config file.
-    NodeConfigLoad { path: PathBuf, err: brane_cfg::info::YamlError },
-}
-
-impl Display for RemoteVmError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use RemoteVmError::*;
-        match self {
-            PlanError { .. } => write!(f, "Failed to plan workflow"),
-            ExecError { .. } => write!(f, "Failed to execute workflow"),
-
-            IllegalNodeConfig { path, got } => {
-                write!(f, "Illegal node config kind in node config '{}'; expected Central, got {}", path.display(), got)
-            },
-            InfraFileLoad { path, .. } => write!(f, "Failed to load infra file '{}'", path.display()),
-            NodeConfigLoad { path, .. } => write!(f, "Failed to load node config file '{}'", path.display()),
-        }
-    }
-}
-
-impl Error for RemoteVmError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use RemoteVmError::*;
-        match self {
-            PlanError { err } => Some(err),
-            ExecError { err } => Some(err),
-
-            IllegalNodeConfig { .. } => None,
-            InfraFileLoad { err, .. } => Some(err),
-            NodeConfigLoad { err, .. } => Some(err),
-        }
-    }
+    #[error("Failed to load node config file '{}'", path.display())]
+    NodeConfigLoad { path: PathBuf, source: brane_cfg::info::YamlError },
 }

--- a/brane-drv/src/handler.rs
+++ b/brane-drv/src/handler.rs
@@ -363,8 +363,8 @@ impl DriverService for DriverHandler {
                     // Serialize the value
                     let sres: String = match serde_json::to_string(&res) {
                         Ok(sres) => sres,
-                        Err(err) => {
-                            fatal_err!(tx, Status::internal, err);
+                        Err(source) => {
+                            fatal_err!(tx, Status::internal, source);
                         },
                     };
 
@@ -377,7 +377,7 @@ impl DriverService for DriverHandler {
                         error!("{}", trace!(("Failed to send workflow result back to client"), err));
                     }
                 },
-                Err(RemoteVmError::PlanError { err: PlanError::CheckerDenied { domain, reasons } }) => {
+                Err(RemoteVmError::PlanError { source: PlanError::CheckerDenied { domain, reasons } }) => {
                     fatal_err!(
                         tx,
                         Status::permission_denied(format!(
@@ -390,8 +390,8 @@ impl DriverService for DriverHandler {
                         ))
                     );
                 },
-                Err(err) => {
-                    fatal_err!(tx, Status::internal, err);
+                Err(source) => {
+                    fatal_err!(tx, Status::internal, source);
                 },
             };
         });

--- a/brane-drv/src/vm.rs
+++ b/brane-drv/src/vm.rs
@@ -128,36 +128,27 @@ impl VmPlugin for InstancePlugin {
         };
 
         // Create the client
-        let mut client: working_grpc::JobServiceClient = match proxy.connect_to_job(delegate_address.to_string()).await {
-            Ok(result) => match result {
-                Ok(client) => client,
-                Err(err) => {
-                    return Err(PreprocessError::GrpcConnectError { endpoint: delegate_address, err });
-                },
-            },
-            Err(err) => {
-                return Err(PreprocessError::ProxyError { err: Box::new(err) });
-            },
-        };
+        let mut client: working_grpc::JobServiceClient = proxy
+            .connect_to_job(delegate_address.to_string())
+            .await
+            .map_err(|source| PreprocessError::ProxyError { source: Box::new(source) })?
+            .map_err(|source| PreprocessError::GrpcConnectError { endpoint: delegate_address.clone(), source })?;
 
         // Send the request to the job node
-        let response: Response<working_grpc::PreprocessReply> = match client.preprocess(message).await {
-            Ok(response) => response,
-            Err(err) => {
-                return Err(PreprocessError::GrpcRequestError { what: "PreprocessRequest", endpoint: delegate_address, err });
-            },
-        };
+        let response: Response<working_grpc::PreprocessReply> = client
+            .preprocess(message)
+            .await
+            .map_err(|source| PreprocessError::GrpcRequestError { what: "PreprocessRequest", endpoint: delegate_address.clone(), source })?;
         let result: working_grpc::PreprocessReply = response.into_inner();
         job.stop();
 
         // If it was, attempt to deserialize the accesskind
         let par = prof.time("Result parsing");
-        let access: AccessKind = match serde_json::from_str(&result.access) {
-            Ok(access) => access,
-            Err(err) => {
-                return Err(PreprocessError::AccessKindParseError { endpoint: delegate_address, raw: result.access, err });
-            },
-        };
+        let access: AccessKind = serde_json::from_str(&result.access).map_err(|source| PreprocessError::AccessKindParseError {
+            endpoint: delegate_address.clone(),
+            raw: result.access,
+            source,
+        })?;
         par.stop();
 
         // Done
@@ -216,25 +207,17 @@ impl VmPlugin for InstancePlugin {
         };
 
         // Create the client
-        let mut client: working_grpc::JobServiceClient = match proxy.connect_to_job(delegate_address.to_string()).await {
-            Ok(result) => match result {
-                Ok(client) => client,
-                Err(err) => {
-                    return Err(ExecuteError::GrpcConnectError { endpoint: delegate_address, err });
-                },
-            },
-            Err(err) => {
-                return Err(ExecuteError::ProxyError { err: Box::new(err) });
-            },
-        };
+        let mut client: working_grpc::JobServiceClient = proxy
+            .connect_to_job(delegate_address.to_string())
+            .await
+            .map_err(|source| ExecuteError::ProxyError { source: Box::new(source) })?
+            .map_err(|source| ExecuteError::GrpcConnectError { endpoint: delegate_address.clone(), source })?;
 
         // Send the request to the job node
-        let response: Response<Streaming<working_grpc::ExecuteReply>> = match client.execute(message).await {
-            Ok(response) => response,
-            Err(err) => {
-                return Err(ExecuteError::GrpcRequestError { what: "ExecuteRequest", endpoint: delegate_address, err });
-            },
-        };
+        let response: Response<Streaming<working_grpc::ExecuteReply>> = client
+            .execute(message)
+            .await
+            .map_err(|source| ExecuteError::GrpcRequestError { what: "ExecuteRequest", endpoint: delegate_address.clone(), source })?;
         let mut stream: Streaming<working_grpc::ExecuteReply> = response.into_inner();
 
         // Now we tick off incoming messages
@@ -376,17 +359,12 @@ impl VmPlugin for InstancePlugin {
         job.stop();
 
         // Now we simply match on the value to see if we got something
-        let result: FullValue = match result {
-            Ok(result) => result,
-            Err(err) => {
-                return Err(ExecuteError::ExecuteError {
-                    endpoint: delegate_address,
-                    name:     info.name.into(),
-                    status:   state.into(),
-                    err:      StringError(err),
-                });
-            },
-        };
+        let result: FullValue = result.map_err(|source| ExecuteError::ExecuteError {
+            endpoint: delegate_address,
+            name:     info.name.into(),
+            status:   state.into(),
+            source:   StringError(source),
+        })?;
 
         // That's it!
         debug!("Task '{}' result: {:?}", info.name, result);
@@ -410,19 +388,16 @@ impl VmPlugin for InstancePlugin {
         };
 
         // Write stdout to the tx
-        if let Err(err) = tx
-            .send(Ok(driving_grpc::ExecuteReply {
-                stdout: Some(format!("{}{}", text, if newline { "\n" } else { "" })),
-                stderr: None,
-                debug:  None,
-                value:  None,
+        tx.send(Ok(driving_grpc::ExecuteReply {
+            stdout: Some(format!("{}{}", text, if newline { "\n" } else { "" })),
+            stderr: None,
+            debug:  None,
+            value:  None,
 
-                close: false,
-            }))
-            .await
-        {
-            return Err(StdoutError::TxWriteError { err });
-        }
+            close: false,
+        }))
+        .await
+        .map_err(|source| StdoutError::TxWriteError { source })?;
 
         // Done
         Ok(())
@@ -479,25 +454,18 @@ impl VmPlugin for InstancePlugin {
         let message: working_grpc::CommitRequest = working_grpc::CommitRequest { result_name: name.into(), data_name: data_name.into() };
 
         // Create the client
-        let mut client: working_grpc::JobServiceClient = match proxy.connect_to_job(delegate_address.to_string()).await {
-            Ok(result) => match result {
-                Ok(client) => client,
-                Err(err) => {
-                    return Err(CommitError::GrpcConnectError { endpoint: delegate_address, err });
-                },
-            },
-            Err(err) => {
-                return Err(CommitError::ProxyError { err: Box::new(err) });
-            },
-        };
+        let mut client: working_grpc::JobServiceClient = proxy
+            .connect_to_job(delegate_address.to_string())
+            .await
+            .map_err(|source| CommitError::ProxyError { source: Box::new(source) })?
+            .map_err(|source| CommitError::GrpcConnectError { endpoint: delegate_address.clone(), source })?;
 
         // Send the request to the job node
-        let response: Response<working_grpc::CommitReply> = match client.commit(message).await {
-            Ok(response) => response,
-            Err(err) => {
-                return Err(CommitError::GrpcRequestError { what: "CommitRequest", endpoint: delegate_address, err });
-            },
-        };
+        let response: Response<working_grpc::CommitReply> = client.commit(message).await.map_err(|source| CommitError::GrpcRequestError {
+            what: "CommitRequest",
+            endpoint: delegate_address.clone(),
+            source,
+        })?;
         let _: working_grpc::CommitReply = response.into_inner();
         job.stop();
 

--- a/brane-drv/src/vm.rs
+++ b/brane-drv/src/vm.rs
@@ -567,20 +567,20 @@ impl InstanceVm {
                         return (self, Err(Error::IllegalNodeConfig { path, got: cfg.node.variant().to_string() }));
                     },
                 },
-                Err(err) => {
+                Err(source) => {
                     let path: PathBuf = global.node_config_path.clone();
                     drop(global);
-                    return (self, Err(Error::NodeConfigLoad { path, err }));
+                    return (self, Err(Error::NodeConfigLoad { path, source }));
                 },
             };
 
             debug!("Loading infra file '{}'...", central_cfg.paths.infra.display());
             let infra: InfraFile = match InfraFile::from_path(&central_cfg.paths.infra) {
                 Ok(infra) => infra,
-                Err(err) => {
+                Err(source) => {
                     let path: PathBuf = global.node_config_path.clone();
                     drop(global);
-                    return (self, Err(Error::InfraFileLoad { path, err }));
+                    return (self, Err(Error::InfraFileLoad { path, source }));
                 },
             };
 
@@ -597,8 +597,8 @@ impl InstanceVm {
         debug!("Planning workflow on Kafka planner...");
         let plan: Workflow = match prof.nest_fut("planning (brane-drv)", |scope| InstancePlanner::plan(&plr_addr, id, workflow, scope)).await {
             Ok(plan) => plan,
-            Err(err) => {
-                return (self, Err(Error::PlanError { err }));
+            Err(source) => {
+                return (self, Err(Error::PlanError { source }));
             },
         };
 
@@ -630,8 +630,8 @@ impl InstanceVm {
         // Match the result to potentially error
         let value: FullValue = match result {
             Ok(value) => value,
-            Err(err) => {
-                return (this, Err(Error::ExecError { err }));
+            Err(source) => {
+                return (this, Err(Error::ExecError { source }));
             },
         };
 

--- a/brane-dsl/Cargo.toml
+++ b/brane-dsl/Cargo.toml
@@ -15,6 +15,7 @@ nom_locate = "4.1.0"
 rand = "0.9.0"
 regex = "1.5.0"
 serde = "1.0.204"
+thiserror = "2.0.0"
 
 brane-shr = { path = "../brane-shr" }
 specifications = { path = "../specifications" }

--- a/brane-exe/Cargo.toml
+++ b/brane-exe/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.22"
 num-traits = "0.2.18"
 serde = "1.0.204"
 serde_json = "1.0.120"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = [] }
 
 brane-ast = { path = "../brane-ast" }

--- a/brane-exe/src/dummy.rs
+++ b/brane-exe/src/dummy.rs
@@ -390,8 +390,8 @@ impl DummyVm {
         // Match the result to potentially error
         let value: FullValue = match result {
             Ok(value) => value,
-            Err(err) => {
-                return (this, Err(Error::ExecError { err }));
+            Err(source) => {
+                return (this, Err(Error::ExecError { source }));
             },
         };
 

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 serde_json_any_key = "2.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "macros", "signal"] }
 tokio-stream = "0.1.6"
 tonic = "0.12.0"

--- a/brane-job/src/errors.rs
+++ b/brane-job/src/errors.rs
@@ -12,50 +12,27 @@
 //!   Defines any errors that occur in the `brane-job` crate.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::path::PathBuf;
 
 
 /***** LIBRARY *****/
 /// Defines errors that relate to the ContainerHashes file.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ContainerHashesError {
     /// Failed to read the given hash file.
-    ReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read hash file '{}'", path.display())]
+    ReadError { path: PathBuf, source: std::io::Error },
     /// Failed to parse the given hash file as the appropriate YAML.
-    ParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse hash file '{}' as YAML", path.display())]
+    ParseError { path: PathBuf, source: serde_yaml::Error },
     /// There was a duplicate hash in there.
+    #[error("Hash file '{}' contains duplicate hash '{}'", path.display(), hash)]
     DuplicateHash { path: PathBuf, hash: String },
 
     /// Failed to serialize the hash file.
-    SerializeError { err: serde_yaml::Error },
+    #[error("Failed to serialize hash file")]
+    SerializeError { source: serde_yaml::Error },
     /// Failed to write to the given file.
-    WriteError { path: PathBuf, err: std::io::Error },
-}
-impl Display for ContainerHashesError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ContainerHashesError::*;
-        match self {
-            ReadError { path, .. } => write!(f, "Failed to read hash file '{}'", path.display()),
-            ParseError { path, .. } => write!(f, "Failed to parse hash file '{}' as YAML", path.display()),
-            DuplicateHash { path, hash } => write!(f, "Hash file '{}' contains duplicate hash '{}'", path.display(), hash),
-
-            SerializeError { .. } => write!(f, "Failed to serialize hash file"),
-            WriteError { path, .. } => write!(f, "Failed to write hash file to '{}'", path.display()),
-        }
-    }
-}
-impl Error for ContainerHashesError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use ContainerHashesError::*;
-        match self {
-            ReadError { err, .. } => Some(err),
-            ParseError { err, .. } => Some(err),
-            DuplicateHash { .. } => None,
-
-            SerializeError { err, .. } => Some(err),
-            WriteError { err, .. } => Some(err),
-        }
-    }
+    #[error("Failed to write hash file to '{}'", path.display())]
+    WriteError { path: PathBuf, source: std::io::Error },
 }

--- a/brane-let/Cargo.toml
+++ b/brane-let/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.22"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["full", "time"] }
 tonic = "0.12.0"
 yaml-rust = { version = "0.8", package = "yaml-rust2" }

--- a/brane-let/src/errors.rs
+++ b/brane-let/src/errors.rs
@@ -12,8 +12,6 @@
 //!   Collects errors for the brane-let applications.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::path::PathBuf;
 
 use brane_ast::DataType;
@@ -23,275 +21,176 @@ use specifications::package::PackageKind;
 
 /***** ERRORS *****/
 /// Generic, top-level errors for the brane-let application.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LetError {
     /// Could not launch the JuiceFS executable
-    JuiceFSLaunchError { command: String, err: std::io::Error },
+    #[error("Could not run JuiceFS command '{command}'")]
+    JuiceFSLaunchError { command: String, source: std::io::Error },
     /// The JuiceFS executable didn't complete successfully
+    #[error(
+        "JuiceFS command '{command}' returned exit code {code}:\n\nstdout:\n{stdout}\n{bar}\n{bar}\n\nstderr:\n{stderr}\n{bar}\n{bar}\n\n",
+        bar = "-".repeat(80)
+    )]
     JuiceFSError { command: String, code: i32, stdout: String, stderr: String },
 
     /// Could not start the proxy redirector in the background
+    #[error("Could not start redirector to '{address}' in the background")]
     RedirectorError { address: String, err: String },
-    // /// Failed to connect to a remote callback while asked
-    // CallbackConnectError{ address: String, err: CallbackError },
     /// Could not decode input arguments with Base64
-    ArgumentsBase64Error { err: base64::DecodeError },
+    #[error("Could not decode input arguments as Base64")]
+    ArgumentsBase64Error { source: base64::DecodeError },
     /// Could not decode input arguments as UTF-8
-    ArgumentsUTF8Error { err: std::string::FromUtf8Error },
+    #[error("Could not decode input arguments as UTF-8")]
+    ArgumentsUTF8Error { source: std::string::FromUtf8Error },
     /// Could not decode input arguments with JSON
-    ArgumentsJSONError { err: serde_json::Error },
+    #[error("Could not parse input arguments as JSON")]
+    ArgumentsJSONError { source: serde_json::Error },
 
     /// Could not load a ContainerInfo file.
-    LocalContainerInfoError { path: PathBuf, err: LocalContainerInfoError },
+    #[error("Could not load local container information file '{}'", path.display())]
+    LocalContainerInfoError { path: PathBuf, source: LocalContainerInfoError },
     /// Could not load a PackageInfo file.
-    PackageInfoError { err: anyhow::Error },
+    #[error("Could not parse package information file from Open-API document")]
+    PackageInfoError { source: anyhow::Error },
     /// Missing the 'functions' property in the package info YAML
+    #[error("Missing property 'functions' in package information file '{}'", path.display())]
     MissingFunctionsProperty { path: PathBuf },
     /// The requested function is not part of the package that this brane-let is responsible for
+    #[error("Unknown function '{}' in package '{}' ({})", function, package, kind.pretty())]
     UnknownFunction { function: String, package: String, kind: PackageKind },
     /// We're missing a required parameter in the function
+    #[error("Parameter '{}' not specified for function '{}' in package '{}' ({})", name, function, package, kind.pretty())]
     MissingInputArgument { function: String, package: String, kind: PackageKind, name: String },
     /// An argument has an incompatible type
+    #[error("Type check failed for parameter '{}' of function '{}' in package '{}' ({}): expected {}, got {}", name, function, package, kind.pretty(), expected, got)]
     IncompatibleTypes { function: String, package: String, kind: PackageKind, name: String, expected: DataType, got: DataType },
     /// Could not start the init.sh workdirectory preparation script
-    WorkdirInitLaunchError { command: String, err: std::io::Error },
+    #[error("Could not run init.sh ('{command}')")]
+    WorkdirInitLaunchError { command: String, source: std::io::Error },
     /// The init.sh workdirectory preparation script returned a non-zero exit code
+    #[error(
+        "init.sh ('{command}') returned exit code {code}:\n\nstdout:\n{stdout}\n{bar}\n{bar}\n\nstderr:\n{stderr}\n{bar}\n{bar}\n\n",
+        bar = "-".repeat(80)
+    )]
     WorkdirInitError { command: String, code: i32, stdout: String, stderr: String },
 
     /// Could not canonicalize the entrypoint file's path
-    EntrypointPathError { path: PathBuf, err: std::io::Error },
+    #[error("Could not canonicalize path '{}'", path.display())]
+    EntrypointPathError { path: PathBuf, source: std::io::Error },
     /// We encountered two arguments with indistinguishable names
+    #[error("Encountered duplicate function argument '{name}'; make sure your names don't conflict in case-insensitive scenarios either")]
     DuplicateArgument { name: String },
     /// We encountered an array element with indistringuishable name from another environment variable
+    #[error(
+        "Element {elem} of array '{array}' has the same name as environment variable '{name}'; remember that arrays generate new arguments for each \
+         element"
+    )]
     DuplicateArrayArgument { array: String, elem: usize, name: String },
     /// We encountered a struct field with indistringuishable name from another environment variable
+    #[error(
+        "Field '{field}' of struct '{sname}' has the same name as environment variable '{name}'; remember that structs generate new arguments for \
+         each field"
+    )]
     DuplicateStructArgument { sname: String, field: String, name: String },
-    /// The user tried to pass an unsupported type to a function
+    /// The user tried to pass an unsuppored type to a function
+    #[error("Argument '{argument}' has type '{elem_type}'; this type is not (yet) supported, please use other types")]
     UnsupportedType { argument: String, elem_type: DataType },
     /// The user tried to give us a nested array, but that's unsupported for now.
+    #[error("Element {elem} of array is an array; nested arrays are not (yet) supported, please use flat arrays only")]
     UnsupportedNestedArray { elem: usize },
     /// The user tried to give us an array with (for now) unsupported element types.
+    #[error("Element {elem} of array has type '{elem_type}'; this type is not (yet) supported in arrays, please use other types")]
     UnsupportedArrayElement { elem: usize, elem_type: String },
     /// The user tried to give us a struct with a nested array.
+    #[error(
+        "Field '{field}' of struct '{name}' is an array; nested arrays in structs are not (yet) supported, please pass arrays separately as flat \
+         arrays"
+    )]
     UnsupportedStructArray { name: String, field: String },
     /// The user tried to pass a nested Directory or File argument without 'url' property.
+    #[error(
+        "Field '{field}' of struct '{name}' is a non-File, non-Directory struct; nested structs are not (yet) supported, please pass structs \
+         separately"
+    )]
     UnsupportedNestedStruct { name: String, field: String },
     /// The user tried to pass a Struct with a general unsupported type.
+    #[error("Field '{field}' of struct '{name}' has type '{elem_type}'; this type is not (yet) supported in structs, please use other types")]
     UnsupportedStructField { name: String, field: String, elem_type: String },
     /// The user tried to pass a nested Directory or File argument without 'url' property.
+    #[error("Field '{field}' of struct '{name}' is a Directory or a File struct, but misses the 'URL' field")]
     IllegalNestedURL { name: String, field: String },
     /// We got an error launching the package
-    PackageLaunchError { command: String, err: std::io::Error },
+    #[error("Could not run nested package call '{command}'")]
+    PackageLaunchError { command: String, source: std::io::Error },
 
     /// The given Open API Standard file does not parse as OAS
-    IllegalOasDocument { path: PathBuf, err: anyhow::Error },
+    #[error("Could not parse OpenAPI specification '{}'", path.display())]
+    IllegalOasDocument { path: PathBuf, source: anyhow::Error },
 
     /// Somehow, we got an error while waiting for the subprocess
-    PackageRunError { err: std::io::Error },
+    #[error("Could not get package run status")]
+    PackageRunError { source: std::io::Error },
     /// The subprocess' stdout wasn't opened successfully
+    #[error("Could not open subprocess stdout")]
     ClosedStdout,
     /// The subprocess' stderr wasn't opened successfully
+    #[error("Could not open subprocess stdout")]
     ClosedStderr,
     /// Could not open stdout
-    StdoutReadError { err: std::io::Error },
+    #[error("Could not read from stdout")]
+    StdoutReadError { source: std::io::Error },
     /// Could not open stderr
-    StderrReadError { err: std::io::Error },
+    #[error("Could not read from stderr")]
+    StderrReadError { source: std::io::Error },
 
     /// Something went wrong while decoding the package output as YAML
-    DecodeError { stdout: String, err: serde_yaml::Error },
+    #[error("Could not parse package stdout:\n{}", stdout)]
+    DecodeError { stdout: String, source: serde_yaml::Error },
     /// Failed to parse the output of an OAS package (which uses JSON instead of YAML cuz OAS)
-    OasDecodeError { stdout: String, err: serde_json::Error },
+    #[error("Could not parse package stdout:\n{}", stdout)]
+    OasDecodeError { stdout: String, source: serde_json::Error },
     /// Encountered more than one output from the function
+    #[error("Function return {n} outputs; this is not (yet) supported, please return only one")]
     UnsupportedMultipleOutputs { n: usize },
 
     /// Failed to encode the input JSON
-    SerializeError { argument: String, data_type: DataType, err: serde_json::Error },
+    #[error("Failed to serialize argument '{argument}' ({data_type}) to JSON")]
+    SerializeError { argument: String, data_type: DataType, source: serde_json::Error },
     /// Could not encode the given array to JSON.
-    ArraySerializeError { argument: String, err: serde_json::Error },
+    #[error("Failed to serialize Array in argument '{argument}' to JSON")]
+    ArraySerializeError { argument: String, source: serde_json::Error },
     /// Could not encode the given class to JSON.
-    ClassSerializeError { argument: String, class: String, err: serde_json::Error },
+    #[error("Failed to serialize Class '{class}' in argument '{argument}' to JSON")]
+    ClassSerializeError { argument: String, class: String, source: serde_json::Error },
     /// Could not write the resulting value to JSON
-    ResultJSONError { value: String, err: serde_json::Error },
+    #[error("Could not serialize value '{value}' to JSON")]
+    ResultJSONError { value: String, source: serde_json::Error },
 }
-
-impl Display for LetError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use LetError::*;
-        match self {
-            JuiceFSLaunchError { command, err } => write!(f, "Could not run JuiceFS command '{command}': {err}"),
-            JuiceFSError { command, code, stdout, stderr } => write!(
-                f,
-                "JuiceFS command '{}' returned exit code {}:\n\nstdout:\n{}\n{}\n{}\n\nstderr:\n{}\n{}\n{}\n\n",
-                command,
-                code,
-                (0..80).map(|_| '-').collect::<String>(),
-                stdout,
-                (0..80).map(|_| '-').collect::<String>(),
-                (0..80).map(|_| '-').collect::<String>(),
-                stderr,
-                (0..80).map(|_| '-').collect::<String>()
-            ),
-
-            RedirectorError { address, err } => write!(f, "Could not start redirector to '{address}' in the background: {err}"),
-            // CallbackConnectError{ address, err } => write!(f, "Could not connect to remote callback node at '{}': {}", address, err),
-            ArgumentsBase64Error { err } => write!(f, "Could not decode input arguments as Base64: {err}"),
-            ArgumentsUTF8Error { err } => write!(f, "Could not decode input arguments as UTF-8: {err}"),
-            ArgumentsJSONError { err } => write!(f, "Could not parse input arguments as JSON: {err}"),
-
-            LocalContainerInfoError { path, err } => write!(f, "Could not load local container information file '{}': {}", path.display(), err),
-            PackageInfoError { err } => write!(f, "Could not parse package information file from Open-API document: {err}"),
-            MissingFunctionsProperty { path } => write!(f, "Missing property 'functions' in package information file '{}'", path.display()),
-            UnknownFunction { function, package, kind } => write!(f, "Unknown function '{}' in package '{}' ({})", function, package, kind.pretty()),
-            MissingInputArgument { function, package, kind, name } => {
-                write!(f, "Parameter '{}' not specified for function '{}' in package '{}' ({})", name, function, package, kind.pretty())
-            },
-            IncompatibleTypes { function, package, kind, name, expected, got } => write!(
-                f,
-                "Type check failed for parameter '{}' of function '{}' in package '{}' ({}): expected {}, got {}",
-                name,
-                function,
-                package,
-                kind.pretty(),
-                expected,
-                got
-            ),
-            WorkdirInitLaunchError { command, err } => write!(f, "Could not run init.sh ('{command}'): {err}"),
-            WorkdirInitError { command, code, stdout, stderr } => write!(
-                f,
-                "init.sh ('{}') returned exit code {}:\n\nstdout:\n{}\n{}\n{}\n\nstderr:\n{}\n{}\n{}\n\n",
-                command,
-                code,
-                (0..80).map(|_| '-').collect::<String>(),
-                stdout,
-                (0..80).map(|_| '-').collect::<String>(),
-                (0..80).map(|_| '-').collect::<String>(),
-                stderr,
-                (0..80).map(|_| '-').collect::<String>()
-            ),
-
-            EntrypointPathError { path, err } => write!(f, "Could not canonicalize path '{}': {}", path.display(), err),
-            DuplicateArgument { name } => write!(
-                f,
-                "Encountered duplicate function argument '{name}'; make sure your names don't conflict in case-insensitive scenarios either"
-            ),
-            DuplicateArrayArgument { array, elem, name } => write!(
-                f,
-                "Element {elem} of array '{array}' has the same name as environment variable '{name}'; remember that arrays generate new arguments \
-                 for each element"
-            ),
-            DuplicateStructArgument { sname, field, name } => write!(
-                f,
-                "Field '{field}' of struct '{sname}' has the same name as environment variable '{name}'; remember that structs generate new \
-                 arguments for each field"
-            ),
-            UnsupportedType { argument, elem_type } => {
-                write!(f, "Argument '{argument}' has type '{elem_type}'; this type is not (yet) supported, please use other types")
-            },
-            UnsupportedNestedArray { elem } => {
-                write!(f, "Element {elem} of array is an array; nested arrays are not (yet) supported, please use flat arrays only")
-            },
-            UnsupportedArrayElement { elem, elem_type } => {
-                write!(f, "Element {elem} of array has type '{elem_type}'; this type is not (yet) supported in arrays, please use other types")
-            },
-            UnsupportedStructArray { name, field } => write!(
-                f,
-                "Field '{field}' of struct '{name}' is an array; nested arrays in structs are not (yet) supported, please pass arrays separately as \
-                 flat arrays"
-            ),
-            UnsupportedNestedStruct { name, field } => write!(
-                f,
-                "Field '{field}' of struct '{name}' is a non-File, non-Directory struct; nested structs are not (yet) supported, please pass \
-                 structs separately"
-            ),
-            UnsupportedStructField { name, field, elem_type } => write!(
-                f,
-                "Field '{field}' of struct '{name}' has type '{elem_type}'; this type is not (yet) supported in structs, please use other types"
-            ),
-            IllegalNestedURL { name, field } => {
-                write!(f, "Field '{field}' of struct '{name}' is a Directory or a File struct, but misses the 'URL' field")
-            },
-            PackageLaunchError { command, err } => write!(f, "Could not run nested package call '{command}': {err}"),
-
-            IllegalOasDocument { path, err } => write!(f, "Could not parse OpenAPI specification '{}': {}", path.display(), err),
-
-            ClosedStdout => write!(f, "Could not open subprocess stdout"),
-            ClosedStderr => write!(f, "Could not open subprocess stdout"),
-            StdoutReadError { err } => write!(f, "Could not read from stdout: {err}"),
-            StderrReadError { err } => write!(f, "Could not read from stderr: {err}"),
-            PackageRunError { err } => write!(f, "Could not get package run status: {err}"),
-
-            DecodeError { stdout, err } => write!(
-                f,
-                "Could not parse package stdout: {}\n\nstdout:\n{}\n{}\n{}\n\n",
-                err,
-                (0..80).map(|_| '-').collect::<String>(),
-                stdout,
-                (0..80).map(|_| '-').collect::<String>()
-            ),
-            OasDecodeError { stdout, err } => write!(
-                f,
-                "Could not parse package stdout: {}\n\nstdout:\n{}\n{}\n{}\n\n",
-                err,
-                (0..80).map(|_| '-').collect::<String>(),
-                stdout,
-                (0..80).map(|_| '-').collect::<String>()
-            ),
-            UnsupportedMultipleOutputs { n } => write!(f, "Function return {n} outputs; this is not (yet) supported, please return only one"),
-
-            SerializeError { argument, data_type, err } => write!(f, "Failed to serialize argument '{argument}' ({data_type}) to JSON: {err}"),
-            ArraySerializeError { argument, err } => write!(f, "Failed to serialize Array in argument '{argument}' to JSON: {err}"),
-            ClassSerializeError { argument, class, err } => write!(f, "Failed to serialize Class '{class}' in argument '{argument}' to JSON: {err}"),
-            ResultJSONError { value, err } => write!(f, "Could not serialize value '{value}' to JSON: {err}"),
-        }
-    }
-}
-
-impl Error for LetError {}
-
-
 
 /// Defines errors that can occur during decoding.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DecodeError {
     /// The input was not valid YAML
-    InvalidYAML { err: yaml_rust::ScanError },
+    #[error("Invalid YAML")]
+    InvalidYAML { source: yaml_rust::ScanError },
     /// The input was not valid JSON
-    InvalidJSON { err: serde_json::Error },
+    #[error("Invalid JSON")]
+    InvalidJSON { source: serde_json::Error },
 
     /// The input is not a valid Hash, i.e., not a valid object (I think)
+    #[error("Top-level YAML is not a valid hash")]
     NotAHash,
     /// Some returned output argument was missing from what the function reported
+    #[error("Missing output argument '{name}' in function output")]
     MissingOutputArgument { name: String },
     /// Some returned output argument has an incorrect type
+    #[error("Function output '{name}' has type '{got}', but expected type '{expected}'")]
     OutputTypeMismatch { name: String, expected: String, got: String },
     /// A given output has a given class type defined, but we don't know about it
+    #[error("Function output '{name}' has object type '{class_name}', but that object type is undefined")]
     UnknownClassType { name: String, class_name: String },
 
     /// Some output struct did not have all its properties defined.
+    #[error("Function output '{name}' has object type '{class_name}', but is missing property '{property_name}'")]
     MissingStructProperty { name: String, class_name: String, property_name: String },
 }
-
-impl Display for DecodeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        match self {
-            DecodeError::InvalidYAML { err } => write!(f, "Invalid YAML: {err}"),
-            DecodeError::InvalidJSON { err } => write!(f, "Invalid JSON: {err}"),
-
-            DecodeError::NotAHash => write!(f, "Top-level YAML is not a valid hash"),
-            DecodeError::MissingOutputArgument { name } => write!(f, "Missing output argument '{name}' in function output"),
-            DecodeError::OutputTypeMismatch { name, expected, got } => {
-                write!(f, "Function output '{name}' has type '{got}', but expected type '{expected}'")
-            },
-            DecodeError::UnknownClassType { name, class_name } => {
-                write!(f, "Function output '{name}' has object type '{class_name}', but that object type is undefined")
-            },
-
-            DecodeError::MissingStructProperty { name, class_name, property_name } => {
-                write!(f, "Function output '{name}' has object type '{class_name}', but is missing property '{property_name}'")
-            },
-        }
-    }
-}
-
-impl Error for DecodeError {}

--- a/brane-prx/Cargo.toml
+++ b/brane-prx/Cargo.toml
@@ -20,6 +20,7 @@ rustls = "0.21.6"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 socksx = { git = "https://github.com/braneframework/socksx", tag = "v2.0.0" }
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-rustls = "0.24.0"
 url = "2.5.0"

--- a/brane-prx/src/errors.rs
+++ b/brane-prx/src/errors.rs
@@ -12,8 +12,6 @@
 //!   Defines the errors that may occur in the `brane-prx` crate.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::net::SocketAddr;
 use std::ops::RangeInclusive;
 
@@ -24,109 +22,75 @@ use url::Url;
 
 /***** LIBRARY *****/
 /// Defines errors that relate to redirection.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RedirectError {
     /// No domain name given in the given URL
+    #[error("No domain name found in '{raw}'")]
     NoDomainName { raw: String },
     /// The given URL is not a valid URL
-    IllegalUrl { raw: String, err: url::ParseError },
+    #[error("Failed to parse '{raw}' as a valid URL")]
+    IllegalUrl { raw: String, source: url::ParseError },
     /// Asked to do TLS with an IP
+    #[error("Got a request for TLS but with a non-hostname {kind} address provided")]
     TlsWithNonHostnameError { kind: String },
     /// The given hostname was illegal
-    IllegalServerName { raw: String, err: rustls::client::InvalidDnsNameError },
+    #[error("Cannot parse '{raw}' as a valid server name")]
+    IllegalServerName { raw: String, source: rustls::client::InvalidDnsNameError },
     /// Failed to create a new tcp listener.
-    ListenerCreateError { address: SocketAddr, err: std::io::Error },
+    #[error("Failed to create new TCP listener on '{address}'")]
+    ListenerCreateError { address: SocketAddr, source: std::io::Error },
     /// Failed to create a new socks5 client.
-    Socks5CreateError { address: Address, err: anyhow::Error },
+    #[error("Failed to create new SOCKS5 client to '{address}'")]
+    Socks5CreateError { address: Address, source: anyhow::Error },
     /// Failed to create a new socks6 client.
-    Socks6CreateError { address: Address, err: anyhow::Error },
+    #[error("Failed to create new SOCKS6 client to '{address}'")]
+    Socks6CreateError { address: Address, source: anyhow::Error },
 
     /// Failed to connect using a regular ol' TcpStream.
-    TcpStreamConnectError { address: String, err: std::io::Error },
+    #[error("Failed to connect to '{address}'")]
+    TcpStreamConnectError { address: String, source: std::io::Error },
     /// Failed to connect using a SOCKS5 client.
-    Socks5ConnectError { address: String, proxy: Address, err: anyhow::Error },
+    #[error("Failed to connect to '{address}' through SOCKS5-proxy '{proxy}'")]
+    Socks5ConnectError { address: String, proxy: Address, source: anyhow::Error },
     /// Failed to connect using a SOCKS6 client.
-    Socks6ConnectError { address: String, proxy: Address, err: anyhow::Error },
+    #[error("Failed to connect to '{address}' through SOCKS6-proxy '{proxy}'")]
+    Socks6ConnectError { address: String, proxy: Address, source: anyhow::Error },
 
     /// The given port for an incoming path is in the outgoing path's range.
+    #[error("Given port '{}' is within range {}-{} of the outgoing connection ports; please choose another (or choose another outgoing port range)", port, range.start(), range.end())]
     PortInOutgoingRange { port: u16, range: RangeInclusive<u16> },
 }
-impl Display for RedirectError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use RedirectError::*;
-        match self {
-            NoDomainName { raw } => write!(f, "No domain name found in '{raw}'"),
-            IllegalUrl { raw, err } => write!(f, "Failed to parse '{raw}' as a valid URL: {err}"),
-            TlsWithNonHostnameError { kind } => write!(f, "Got a request for TLS but with a non-hostname {kind} address provided"),
-            IllegalServerName { raw, err } => write!(f, "Cannot parse '{raw}' as a valid server name: {err}"),
-            ListenerCreateError { address, err } => write!(f, "Failed to create new TCP listener on '{address}': {err}"),
-            Socks5CreateError { address, err } => write!(f, "Failed to create new SOCKS5 client to '{address}': {err}"),
-            Socks6CreateError { address, err } => write!(f, "Failed to create new SOCKS6 client to '{address}': {err}"),
-
-            TcpStreamConnectError { address, err } => write!(f, "Failed to connect to '{address}': {err}"),
-            Socks5ConnectError { address, proxy, err } => write!(f, "Failed to connect to '{address}' through SOCKS5-proxy '{proxy}': {err}"),
-            Socks6ConnectError { address, proxy, err } => write!(f, "Failed to connect to '{address}' through SOCKS6-proxy '{proxy}': {err}"),
-
-            PortInOutgoingRange { port, range } => write!(
-                f,
-                "Given port '{}' is within range {}-{} of the outgoing connection ports; please choose another (or choose another outgoing port \
-                 range)",
-                port,
-                range.start(),
-                range.end()
-            ),
-        }
-    }
-}
-impl Error for RedirectError {}
-
 
 
 /// Defines errors for clients of the proxy.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ClientError {
     /// The given URL was not a URL
-    IllegalUrl { raw: String, err: url::ParseError },
+    #[error("'{raw}' is not a valid URL")]
+    IllegalUrl { raw: String, source: url::ParseError },
     /// Failed to update the given URL with a new scheme.
+    #[error("Failed to update '{url}' with new scheme '{scheme}'")]
     UrlSchemeUpdateError { url: Url, scheme: String },
     /// Failed to update the given URL with a new host.
-    UrlHostUpdateError { url: Url, host: String, err: url::ParseError },
+    #[error("Failed to update '{url}' with new host '{host}'")]
+    UrlHostUpdateError { url: Url, host: String, source: url::ParseError },
     /// Failed to update the given URL with a new port.
+    #[error("Failed to update '{url}' with new port '{port}'")]
     UrlPortUpdateError { url: Url, port: u16 },
 
     /// Failed to build a request.
-    RequestBuildError { address: String, err: reqwest::Error },
+    #[error("Failed to build a request to '{address}'")]
+    RequestBuildError { address: String, source: reqwest::Error },
     /// Failed to send a request on its way.
-    RequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send request to '{address}'")]
+    RequestError { address: String, source: reqwest::Error },
     /// The request failed with a non-success status code.
+    #[error("Request to '{}' failed with status code {} ({}){}", address, code.as_u16(), code.canonical_reason().unwrap_or("??"), if let Some(err) = err { format!(": {err}") } else { String::new() })]
     RequestFailure { address: String, code: StatusCode, err: Option<String> },
     /// Failed to get the body of a response as some text.
-    RequestTextError { address: String, err: reqwest::Error },
+    #[error("Failed to get body of response from '{address}' as plain text")]
+    RequestTextError { address: String, source: reqwest::Error },
     /// Failed to parse the response's body as a port number.
-    RequestPortParseError { address: String, raw: String, err: std::num::ParseIntError },
+    #[error("Failed to parse '{raw}' received from '{address}' as a port number")]
+    RequestPortParseError { address: String, raw: String, source: std::num::ParseIntError },
 }
-impl Display for ClientError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ClientError::*;
-        match self {
-            IllegalUrl { raw, err } => write!(f, "'{raw}' is not a valid URL: {err}"),
-            UrlSchemeUpdateError { url, scheme } => write!(f, "Failed to update '{url}' with new scheme '{scheme}'"),
-            UrlHostUpdateError { url, host, err } => write!(f, "Failed to update '{url}' with new host '{host}': {err}"),
-            UrlPortUpdateError { url, port } => write!(f, "Failed to update '{url}' with new port '{port}'"),
-
-            RequestBuildError { address, err } => write!(f, "Failed to build a request to '{address}': {err}"),
-            RequestError { address, err } => write!(f, "Failed to send request to '{address}': {err}"),
-            RequestFailure { address, code, err } => write!(
-                f,
-                "Request to '{}' failed with status code {} ({}){}",
-                address,
-                code.as_u16(),
-                code.canonical_reason().unwrap_or("??"),
-                if let Some(err) = err { format!(": {err}") } else { String::new() }
-            ),
-            RequestTextError { address, err } => write!(f, "Failed to get body of response from '{address}' as plain text: {err}"),
-            RequestPortParseError { address, raw, err } => write!(f, "Failed to parse '{raw}' received from '{address}' as a port number: {err}"),
-        }
-    }
-}
-impl Error for ClientError {}

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.204", features = ["rc"] }
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 tempfile = "3.10.1"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["rt","rt-multi-thread","macros","io-util", "signal"] }
 tokio-rustls = "0.24.0"
 warp = "0.3.2"

--- a/brane-reg/src/errors.rs
+++ b/brane-reg/src/errors.rs
@@ -12,211 +12,101 @@
 //!   Defines the errors that may occur in the `brane-reg` crate.
 //
 
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FResult};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-
 /***** LIBRARY *****/
 /// Defines Store-related errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum StoreError {
     /// Failed to parse from the given reader.
-    ReaderParseError { err: serde_yaml::Error },
+    #[error("Failed to parse the given store reader as YAML")]
+    ReaderParseError { source: serde_yaml::Error },
 
     /// Failed to open the store file.
-    FileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open store file '{}'", path.display())]
+    FileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to parse the store file.
-    FileParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse store file '{}' as YAML", path.display())]
+    FileParseError { path: PathBuf, source: serde_yaml::Error },
 
     /// Failed to read the given directory.
-    DirReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read directory '{}'", path.display())]
+    DirReadError { path: PathBuf, source: std::io::Error },
     /// Failed to read an entry in the given directory.
-    DirReadEntryError { path: PathBuf, i: usize, err: std::io::Error },
+    #[error("Failed to read entry {} in directory '{}'", i, path.display())]
+    DirReadEntryError { path: PathBuf, i: usize, source: std::io::Error },
     /// Failed to read the AssetInfo file.
-    AssetInfoReadError { path: PathBuf, err: specifications::data::AssetInfoError },
+    #[error("Failed to load asset info file '{}'", path.display())]
+    AssetInfoReadError { path: PathBuf, source: specifications::data::AssetInfoError },
 }
-
-impl Display for StoreError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use StoreError::*;
-        match self {
-            ReaderParseError { .. } => write!(f, "Failed to parse the given store reader as YAML"),
-
-            FileOpenError { path, .. } => write!(f, "Failed to open store file '{}'", path.display()),
-            FileParseError { path, .. } => write!(f, "Failed to parse store file '{}' as YAML", path.display()),
-
-            DirReadError { path, .. } => write!(f, "Failed to read directory '{}'", path.display()),
-            DirReadEntryError { path, i, .. } => write!(f, "Failed to read entry {} in directory '{}'", i, path.display()),
-            AssetInfoReadError { path, .. } => write!(f, "Failed to load asset info file '{}'", path.display()),
-        }
-    }
-}
-
-impl Error for StoreError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use StoreError::*;
-        match self {
-            ReaderParseError { err } => Some(err),
-
-            FileOpenError { err, .. } => Some(err),
-            FileParseError { err, .. } => Some(err),
-
-            DirReadError { err, .. } => Some(err),
-            DirReadEntryError { err, .. } => Some(err),
-            AssetInfoReadError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Errors that relate to the customized serving process of warp.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ServerError {
     /// Failed to create a new TcpListener and bind it to the given address.
-    ServerBindError { address: SocketAddr, err: std::io::Error },
+    #[error("Failed to bind new TCP server to '{address}'")]
+    ServerBindError { address: SocketAddr, source: std::io::Error },
     /// Failed to load the keypair.
-    KeypairLoadError { err: brane_cfg::certs::Error },
+    #[error("Failed to load keypair")]
+    KeypairLoadError { source: brane_cfg::certs::Error },
     /// Failed to load the certificate root store.
-    StoreLoadError { err: brane_cfg::certs::Error },
+    #[error("Failed to load root store")]
+    StoreLoadError { source: brane_cfg::certs::Error },
     /// Failed to create a new ServerConfig for the TLS setup.
-    ServerConfigError { err: rustls::Error },
+    #[error("Failed to create new TLS server configuration")]
+    ServerConfigError { source: rustls::Error },
 }
-
-impl Display for ServerError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ServerError::*;
-        match self {
-            ServerBindError { address, .. } => write!(f, "Failed to bind new TCP server to '{address}'"),
-            KeypairLoadError { .. } => write!(f, "Failed to load keypair"),
-            StoreLoadError { .. } => write!(f, "Failed to load root store"),
-            ServerConfigError { .. } => write!(f, "Failed to create new TLS server configuration"),
-        }
-    }
-}
-
-impl Error for ServerError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use ServerError::*;
-        match self {
-            ServerBindError { err, .. } => Some(err),
-            KeypairLoadError { err } => Some(err),
-            StoreLoadError { err } => Some(err),
-            ServerConfigError { err } => Some(err),
-        }
-    }
-}
-
-
 
 /// Errors that relate to the `/data` path (and nested).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DataError {
     /// Failed to serialize the contents of the store file (i.e., all known datasets)
-    StoreSerializeError { err: serde_json::Error },
+    #[error("Failed to serialize known datasets")]
+    StoreSerializeError { source: serde_json::Error },
     /// Failed to serialize the contents of a single dataset.
-    AssetSerializeError { name: String, err: serde_json::Error },
+    #[error("Failed to serialize dataset metadata for dataset '{name}'")]
+    AssetSerializeError { name: String, source: serde_json::Error },
 
     /// Failed to create a temporary directory.
-    TempDirCreateError { err: std::io::Error },
+    #[error("Failed to create a temporary directory")]
+    TempDirCreateError { source: std::io::Error },
     /// Failed to archive the given dataset.
-    DataArchiveError { err: brane_shr::fs::Error },
+    #[error("Failed to archive data")]
+    DataArchiveError { source: brane_shr::fs::Error },
     /// Failed to re-open the tar file after compressing.
-    TarOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to re-open tarball file '{}'", path.display())]
+    TarOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read from the tar file.
-    TarReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read from tarball file '{}'", path.display())]
+    TarReadError { path: PathBuf, source: std::io::Error },
     /// Failed to send chunk of bytes on the body.
-    TarSendError { err: warp::hyper::Error },
+    #[error("Failed to send chunk of tarball file as body")]
+    TarSendError { source: warp::hyper::Error },
     /// The given file was not a file, nor a directory.
+    #[error("Dataset file '{}' is neither a file, nor a directory; don't know what to do with it", path.display())]
     UnknownFileTypeError { path: PathBuf },
     /// The given data path does not point to a data set, curiously enough.
+    #[error("The data of dataset '{}' should be at '{}', but doesn't exist", name, path.display())]
     MissingData { name: String, path: PathBuf },
     /// The given result does not point to a data set, curiously enough.
+    #[error("The data of intermediate result '{}' should be at '{}', but doesn't exist", name, path.display())]
     MissingResult { name: String, path: PathBuf },
-}
-
-impl Display for DataError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DataError::*;
-        match self {
-            StoreSerializeError { .. } => write!(f, "Failed to serialize known datasets"),
-            AssetSerializeError { name, .. } => write!(f, "Failed to serialize dataset metadata for dataset '{name}'"),
-
-            TempDirCreateError { .. } => write!(f, "Failed to create a temporary directory"),
-            DataArchiveError { .. } => write!(f, "Failed to archive data"),
-            TarOpenError { path, .. } => write!(f, "Failed to re-open tarball file '{}'", path.display()),
-            TarReadError { path, .. } => write!(f, "Failed to read from tarball file '{}'", path.display()),
-            TarSendError { .. } => write!(f, "Failed to send chunk of tarball file as body"),
-            UnknownFileTypeError { path } => {
-                write!(f, "Dataset file '{}' is neither a file, nor a directory; don't know what to do with it", path.display())
-            },
-            MissingData { name, path } => write!(f, "The data of dataset '{}' should be at '{}', but doesn't exist", name, path.display()),
-            MissingResult { name, path } => {
-                write!(f, "The data of intermediate result '{}' should be at '{}', but doesn't exist", name, path.display())
-            },
-        }
-    }
-}
-
-impl Error for DataError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use DataError::*;
-        match self {
-            StoreSerializeError { err } => Some(err),
-            AssetSerializeError { err, .. } => Some(err),
-
-            TempDirCreateError { err } => Some(err),
-            DataArchiveError { err } => Some(err),
-            TarOpenError { err, .. } => Some(err),
-            TarReadError { err, .. } => Some(err),
-            TarSendError { err, .. } => Some(err),
-            UnknownFileTypeError { .. } => None,
-            MissingData { .. } => None,
-            MissingResult { .. } => None,
-        }
-    }
 }
 
 impl warp::reject::Reject for DataError {}
 
-
-
 /// Errors that relate to checker authorization.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum AuthorizeError {
     /// The client did not provide us with a certificate.
+    #[error("No certificate provided")]
     ClientNoCert,
 
     /// Failed to load the policy file.
-    PolicyFileError { err: brane_cfg::policies::Error },
+    #[error("Failed to load policy file")]
+    PolicyFileError { source: brane_cfg::policies::Error },
     /// No policy matched this user/data pair.
+    #[error("No matching policy rule found for user '{user}' / data '{data}' (did you forget a final AllowAll/DenyAll?)")]
     NoUserPolicy { user: String, data: String },
-}
-
-impl Display for AuthorizeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use AuthorizeError::*;
-        match self {
-            ClientNoCert => write!(f, "No certificate provided"),
-
-            PolicyFileError { .. } => write!(f, "Failed to load policy file"),
-            NoUserPolicy { user, data } => {
-                write!(f, "No matching policy rule found for user '{user}' / data '{data}' (did you forget a final AllowAll/DenyAll?)")
-            },
-        }
-    }
-}
-
-impl Error for AuthorizeError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use AuthorizeError::*;
-        match self {
-            ClientNoCert => None,
-
-            PolicyFileError { err } => Some(err),
-            NoUserPolicy { .. } => None,
-        }
-    }
 }

--- a/brane-shr/Cargo.toml
+++ b/brane-shr/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4.22"
 regex = "1.5.0"
 reqwest = { version = "0.12.0", features = ["stream"] }
 sha2 = "0.10.6"
+thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["rt","macros"] }
 tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1.0.204"
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 sha2 = "0.10.6"
+thiserror = "2.0.0"
 tokio = "1.38.0"
 tokio-tar = "0.3.0"
 tokio-util = "0.7.1"

--- a/brane-tsk/src/errors.rs
+++ b/brane-tsk/src/errors.rs
@@ -39,1267 +39,665 @@ use tonic::Status;
 
 /***** AUXILLARY *****/
 /// Turns a [`String`] into something that [`Error`]s.
+// FIXME: either use enumerated errors or use something like anyhow
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct StringError(pub String);
 impl Display for StringError {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FResult { write!(f, "{}", self.0) }
 }
+
 impl Error for StringError {}
-
-
-
-
 
 /***** LIBRARY *****/
 /// Defines a kind of combination of all the possible errors that may occur in the process.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum TaskError {
     /// Something went wrong while planning.
-    PlanError { err: PlanError },
+    #[error("Failed to plan workflow")]
+    PlanError { source: PlanError },
     /// Something went wrong while executing.
-    ExecError { err: brane_exe::errors::VmError },
+    #[error("Failed to execute workflow")]
+    ExecError { source: brane_exe::errors::VmError },
 }
-impl Display for TaskError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use TaskError::*;
-        match self {
-            PlanError { .. } => write!(f, "Failed to plan workflow"),
-            ExecError { .. } => write!(f, "Failed to execute workflow"),
-        }
-    }
-}
-impl Error for TaskError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use TaskError::*;
-        match self {
-            PlanError { err } => Some(err),
-            ExecError { err } => Some(err),
-        }
-    }
-}
-
-
-
-
 
 /// Defines common errors that occur when trying to plan a workflow.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PlanError {
     /// Failed to load the infrastructure file.
-    InfraFileLoadError { err: brane_cfg::infra::Error },
+    #[error("Failed to load infrastructure file")]
+    InfraFileLoadError { source: brane_cfg::infra::Error },
 
     /// The user didn't specify the location (specifically enough).
+    #[error("Ambigious location for task '{}': {}", name, if let Locations::Restricted(locs) = locs { format!("possible locations are {}, but you need to reduce that to only 1 (use On-structs for that)", locs.join(", ")) } else { "all locations are possible, but you need to reduce that to only 1 (use On-structs for that)".into() })]
     AmbigiousLocationError { name: String, locs: Locations },
     /// Failed to send a request to the API service.
-    RequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send GET-request to '{address}'")]
+    RequestError { address: String, source: reqwest::Error },
     /// The request failed with a non-OK status code
+    #[error("GET-request to '{}' failed with {} ({}){}", address, code, code.canonical_reason().unwrap_or("???"), if let Some(err) = err { format!("\n\nResponse:\n{}\n", BlockFormatter::new(err)) } else { String::new() })]
     RequestFailure { address: String, code: reqwest::StatusCode, err: Option<String> },
     /// Failed to get the body of a request.
-    RequestBodyError { address: String, err: reqwest::Error },
+    #[error("Failed to get the body of response from '{address}' as UTF-8 text")]
+    RequestBodyError { address: String, source: reqwest::Error },
     /// Failed to parse the body of the request as valid JSON
-    RequestParseError { address: String, raw: String, err: serde_json::Error },
+    #[error("Failed to parse response '{raw}' from '{address}' as valid JSON")]
+    RequestParseError { address: String, raw: String, source: serde_json::Error },
     /// The planned domain does not support the task.
+    #[error("Location '{loc}' only supports capabilities {got:?}, whereas task '{task}' requires capabilities {expected:?}")]
     UnsupportedCapabilities { task: String, loc: String, expected: HashSet<Capability>, got: HashSet<Capability> },
     /// The given dataset was unknown to us.
+    #[error("Unknown dataset '{name}'")]
     UnknownDataset { name: String },
     /// The given intermediate result was unknown to us.
+    #[error("Unknown intermediate result '{name}'")]
     UnknownIntermediateResult { name: String },
     /// We failed to insert one of the dataset in the runtime set.
-    DataPlanError { err: specifications::data::RuntimeDataIndexError },
+    #[error("Failed to plan dataset")]
+    DataPlanError { source: specifications::data::RuntimeDataIndexError },
     /// We can't access a dataset in the local instance.
+    #[error("Dataset '{}' is unavailable{}", name, if !locs.is_empty() { format!( "; however, locations {} do (try to get download permission to those datasets)", locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")) } else { String::new() })]
     DatasetUnavailable { name: String, locs: Vec<String> },
     /// We can't access an intermediate result in the local instance.
+    #[error("Intermediate result '{}' is unavailable{}", name, if !locs.is_empty() { format!( "; however, locations {} do (try to get download permission to those datasets)", locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")) } else { String::new() })]
     IntermediateResultUnavailable { name: String, locs: Vec<String> },
 
     // Instance-only
     /// Failed to serialize the internal workflow.
-    WorkflowSerialize { id: String, err: serde_json::Error },
+    #[error("Failed to serialize workflow '{id}'")]
+    WorkflowSerialize { id: String, source: serde_json::Error },
     /// Failed to serialize the [`PlanningRequest`](specifications::planning::PlanningRequest).
-    PlanningRequestSerialize { id: String, err: serde_json::Error },
+    #[error("Failed to serialize planning request for workflow '{id}'")]
+    PlanningRequestSerialize { id: String, source: serde_json::Error },
     /// Failed to create a request to plan at the planner.
-    PlanningRequest { id: String, url: String, err: reqwest::Error },
+    #[error("Failed to create request to plan workflow '{id}' for '{url}'")]
+    PlanningRequest { id: String, url: String, source: reqwest::Error },
     /// Failed to send a request to plan at the planner.
-    PlanningRequestSend { id: String, url: String, err: reqwest::Error },
+    #[error("Failed to send request to plan workflow '{id}' to '{url}'")]
+    PlanningRequestSend { id: String, url: String, source: reqwest::Error },
     /// The server failed to plan.
+    #[error("Planner failed to plan workflow '{}' (server at '{url}' returned {} ({})){}", id, code.as_u16(), code.canonical_reason().unwrap_or("???"), if let Some(res) = response { format!("\n\nResponse:\n{}\n", BlockFormatter::new(res)) } else { String::new() })]
     PlanningFailure { id: String, url: String, code: StatusCode, response: Option<String> },
     /// Failed to download the server's response.
-    PlanningResponseDownload { id: String, url: String, err: reqwest::Error },
+    #[error("Failed to download response from '{url}' for workflow '{id}'")]
+    PlanningResponseDownload { id: String, url: String, source: reqwest::Error },
     /// failed to parse the server's response.
-    PlanningResponseParse { id: String, url: String, raw: String, err: serde_json::Error },
+    #[error("Failed to parse response from '{}' to planning workflow '{}'\n\nResponse:\n{}\n", url, id, BlockFormatter::new(raw))]
+    PlanningResponseParse { id: String, url: String, raw: String, source: serde_json::Error },
     /// Failed to parse the server's returned plan.
-    PlanningPlanParse { id: String, url: String, raw: Value, err: serde_json::Error },
+    #[error("Failed to parse plan returned by '{}' to plan workflow '{}'\n\nPlan:\n{}\n", url, id, BlockFormatter::new(format!("{:?}", raw)))]
+    PlanningPlanParse { id: String, url: String, raw: Value, source: serde_json::Error },
 
     /// Failed to a checker to validate the workflow
-    GrpcConnectError { endpoint: Address, err: specifications::working::JobServiceError },
+    #[error("Failed to create gRPC connection to `brane-job` service at '{endpoint}'")]
+    GrpcConnectError { endpoint: Address, source: specifications::working::JobServiceError },
     /// Failed to connect to the proxy service
-    ProxyError { err: Box<dyn 'static + Send + Error> },
+    #[error("Failed to use `brane-prx` service")]
+    ProxyError { source: Box<dyn 'static + Send + Error> },
     /// Failed to submit the gRPC request to validate a workflow.
-    GrpcRequestError { what: &'static str, endpoint: Address, err: tonic::Status },
+    #[error("Failed to send {what} over gRPC connection to `brane-job` service at '{endpoint}'")]
+    GrpcRequestError { what: &'static str, endpoint: Address, source: tonic::Status },
     /// One of the checkers denied everything :/
+    #[error("Checker of domain '{domain}' denied plan{}", if !reasons.is_empty() { format!( "\n\nReasons:\n{}", reasons.iter().fold(String::new(), |mut output, r| { let _ = writeln!(output, "  - {r}"); output })) } else { String::new() })]
     CheckerDenied { domain: Location, reasons: Vec<String> },
 }
-impl Display for PlanError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use PlanError::*;
-        match self {
-            InfraFileLoadError { .. } => write!(f, "Failed to load infrastructure file"),
-
-            AmbigiousLocationError { name, locs } => write!(
-                f,
-                "Ambigious location for task '{}': {}",
-                name,
-                if let Locations::Restricted(locs) = locs {
-                    format!("possible locations are {}, but you need to reduce that to only 1 (use On-structs for that)", locs.join(", "))
-                } else {
-                    "all locations are possible, but you need to reduce that to only 1 (use On-structs for that)".into()
-                }
-            ),
-            RequestError { address, .. } => write!(f, "Failed to send GET-request to '{address}'"),
-            RequestFailure { address, code, err } => write!(
-                f,
-                "GET-request to '{}' failed with {} ({}){}",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(err) = err { format!("\n\nResponse:\n{}\n", BlockFormatter::new(err)) } else { String::new() }
-            ),
-            RequestBodyError { address, .. } => write!(f, "Failed to get the body of response from '{address}' as UTF-8 text"),
-            RequestParseError { address, raw, .. } => write!(f, "Failed to parse response '{raw}' from '{address}' as valid JSON"),
-            UnsupportedCapabilities { task, loc, expected, got } => {
-                write!(f, "Location '{loc}' only supports capabilities {got:?}, whereas task '{task}' requires capabilities {expected:?}")
-            },
-            UnknownDataset { name } => write!(f, "Unknown dataset '{name}'"),
-            UnknownIntermediateResult { name } => write!(f, "Unknown intermediate result '{name}'"),
-            DataPlanError { .. } => write!(f, "Failed to plan dataset"),
-            DatasetUnavailable { name, locs } => write!(
-                f,
-                "Dataset '{}' is unavailable{}",
-                name,
-                if !locs.is_empty() {
-                    format!(
-                        "; however, locations {} do (try to get download permission to those datasets)",
-                        locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")
-                    )
-                } else {
-                    String::new()
-                }
-            ),
-            IntermediateResultUnavailable { name, locs } => write!(
-                f,
-                "Intermediate result '{}' is unavailable{}",
-                name,
-                if !locs.is_empty() {
-                    format!(
-                        "; however, locations {} do (try to get download permission to those datasets)",
-                        locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")
-                    )
-                } else {
-                    String::new()
-                }
-            ),
-
-            WorkflowSerialize { id, .. } => write!(f, "Failed to serialize workflow '{id}'"),
-            PlanningRequestSerialize { id, .. } => write!(f, "Failed to serialize planning request for workflow '{id}'"),
-            PlanningRequest { id, url, .. } => write!(f, "Failed to create request to plan workflow '{id}' for '{url}'"),
-            PlanningRequestSend { id, url, .. } => write!(f, "Failed to send request to plan workflow '{id}' to '{url}'"),
-            PlanningFailure { id, url, code, response } => write!(
-                f,
-                "Planner failed to plan workflow '{}' (server at '{url}' returned {} ({})){}",
-                id,
-                code.as_u16(),
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(res) = response { format!("\n\nResponse:\n{}\n", BlockFormatter::new(res)) } else { String::new() }
-            ),
-            PlanningResponseDownload { id, url, .. } => write!(f, "Failed to download response from '{url}' for workflow '{id}'"),
-            PlanningResponseParse { id, url, raw, .. } => {
-                write!(f, "Failed to parse response from '{}' to planning workflow '{}'\n\nResponse:\n{}\n", url, id, BlockFormatter::new(raw))
-            },
-            PlanningPlanParse { id, url, raw, .. } => write!(
-                f,
-                "Failed to parse plan returned by '{}' to plan workflow '{}'\n\nPlan:\n{}\n",
-                url,
-                id,
-                BlockFormatter::new(format!("{:?}", raw))
-            ),
-
-            GrpcConnectError { endpoint, .. } => write!(f, "Failed to create gRPC connection to `brane-job` service at '{endpoint}'"),
-            ProxyError { .. } => write!(f, "Failed to use `brane-prx` service"),
-            GrpcRequestError { what, endpoint, .. } => write!(f, "Failed to send {what} over gRPC connection to `brane-job` service at '{endpoint}'"),
-            CheckerDenied { domain, reasons } => write!(
-                f,
-                "Checker of domain '{domain}' denied plan{}",
-                if !reasons.is_empty() {
-                    format!(
-                        "\n\nReasons:\n{}",
-                        reasons.iter().fold(String::new(), |mut output, r| {
-                            let _ = writeln!(output, "  - {r}");
-                            output
-                        })
-                    )
-                } else {
-                    String::new()
-                }
-            ),
-        }
-    }
-}
-impl Error for PlanError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use PlanError::*;
-        match self {
-            InfraFileLoadError { err } => Some(err),
-
-            AmbigiousLocationError { .. } => None,
-            RequestError { err, .. } => Some(err),
-            RequestFailure { .. } => None,
-            RequestBodyError { err, .. } => Some(err),
-            RequestParseError { err, .. } => Some(err),
-            UnsupportedCapabilities { .. } => None,
-            UnknownDataset { .. } => None,
-            UnknownIntermediateResult { .. } => None,
-            DataPlanError { err } => Some(err),
-            DatasetUnavailable { .. } => None,
-            IntermediateResultUnavailable { .. } => None,
-
-            WorkflowSerialize { err, .. } => Some(err),
-            PlanningRequestSerialize { err, .. } => Some(err),
-            PlanningRequest { err, .. } => Some(err),
-            PlanningRequestSend { err, .. } => Some(err),
-            PlanningFailure { .. } => None,
-            PlanningResponseDownload { err, .. } => Some(err),
-            PlanningResponseParse { err, .. } => Some(err),
-            PlanningPlanParse { err, .. } => Some(err),
-
-            GrpcConnectError { err, .. } => Some(err),
-            ProxyError { err } => Some(&**err),
-            GrpcRequestError { err, .. } => Some(err),
-            CheckerDenied { .. } => None,
-        }
-    }
-}
-
-
 
 /// Defines common errors that occur when trying to preprocess datasets.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PreprocessError {
     /// The dataset was _still_ unavailable after preprocessing
+    #[error("{} '{}' is not available locally", name.variant(), name.name())]
     UnavailableData { name: DataName },
 
     // Instance only (client-side)
     /// Failed to load the node config file.
-    NodeConfigReadError { path: PathBuf, err: brane_cfg::info::YamlError },
+    #[error("Failed to load node config file '{}'", path.display())]
+    NodeConfigReadError { path: PathBuf, source: brane_cfg::info::YamlError },
     /// Failed to load the infra file.
-    InfraReadError { path: PathBuf, err: brane_cfg::infra::Error },
+    #[error("Failed to load infrastructure file '{}'", path.display())]
+    InfraReadError { path: PathBuf, source: brane_cfg::infra::Error },
     /// The given location was unknown.
+    #[error("Unknown location '{loc}'")]
     UnknownLocationError { loc: Location },
     /// Failed to connect to a proxy.
-    ProxyError { err: Box<dyn 'static + Send + Sync + Error> },
+    #[error("Failed to prepare proxy service")]
+    ProxyError { source: Box<dyn 'static + Send + Sync + Error> },
     /// Failed to connect to a delegate node with gRPC
-    GrpcConnectError { endpoint: Address, err: specifications::working::Error },
+    #[error("Failed to start gRPC connection with delegate node '{endpoint}'")]
+    GrpcConnectError { endpoint: Address, source: specifications::working::Error },
     /// Failed to send a preprocess request to a delegate node with gRPC
-    GrpcRequestError { what: &'static str, endpoint: Address, err: tonic::Status },
+    #[error("Failed to send {what} request to delegate node '{endpoint}'")]
+    GrpcRequestError { what: &'static str, endpoint: Address, source: tonic::Status },
     /// Failed to re-serialize the access kind.
-    AccessKindParseError { endpoint: Address, raw: String, err: serde_json::Error },
+    #[error("Failed to parse access kind '{raw}' sent by remote delegate '{endpoint}'")]
+    AccessKindParseError { endpoint: Address, raw: String, source: serde_json::Error },
 
-    // Instance only (worker-side)
-    // /// Failed to load the keypair.
-    // KeypairLoadError{ err: brane_cfg::certs::Error },
-    // /// Failed to load the certificate root store.
-    // StoreLoadError{ err: brane_cfg::certs::Error },
-    // /// The given certificate file was empty.
-    // EmptyCertFile{ path: PathBuf },
-    // /// Failed to parse the given key/cert pair as an IdentityFile.
-    // IdentityFileError{ certfile: PathBuf, keyfile: PathBuf, err: reqwest::Error },
-    // /// Failed to load the given certificate as PEM root certificate.
-    // RootError{ cafile: PathBuf, err: reqwest::Error },
     /// Failed to open/read a given file.
-    FileReadError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to read {} file '{}'", what, path.display())]
+    FileReadError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to parse an identity file.
-    IdentityFileError { path: PathBuf, err: reqwest::Error },
+    #[error("Failed to parse identity file '{}'", path.display())]
+    IdentityFileError { path: PathBuf, source: reqwest::Error },
     /// Failed to parse a certificate.
-    CertificateError { path: PathBuf, err: reqwest::Error },
+    #[error("Failed to parse certificate '{}'", path.display())]
+    CertificateError { path: PathBuf, source: reqwest::Error },
     /// Failed to resolve a location identifier to a registry address.
-    LocationResolve { id: String, err: crate::caches::DomainRegistryCacheError },
+    #[error("Failed to resolve location ID '{id}' to a local registry address")]
+    LocationResolve { id: String, source: crate::caches::DomainRegistryCacheError },
     /// A directory was not a directory but a file.
+    #[error("{} directory '{}' is not a directory", what.capitalize(), path.display())]
     DirNotADirError { what: &'static str, path: PathBuf },
     /// A directory what not a directory because it didn't exist.
+    #[error("{} directory '{}' doesn't exist", what.capitalize(), path.display())]
     DirNotExistsError { what: &'static str, path: PathBuf },
     /// A directory could not be removed.
-    DirRemoveError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to remove {} directory '{}'", what, path.display())]
+    DirRemoveError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// A directory could not be created.
-    DirCreateError { what: &'static str, path: PathBuf, err: std::io::Error },
+    #[error("Failed to create {} directory '{}'", what, path.display())]
+    DirCreateError { what: &'static str, path: PathBuf, source: std::io::Error },
     /// Failed to create a reqwest proxy object.
-    ProxyCreateError { address: Address, err: reqwest::Error },
+    #[error("Failed to create proxy to '{address}'")]
+    ProxyCreateError { address: Address, source: reqwest::Error },
     /// Failed to create a reqwest client.
-    ClientCreateError { err: reqwest::Error },
+    #[error("Failed to create HTTP-client")]
+    ClientCreateError { source: reqwest::Error },
     /// Failed to send a GET-request to fetch the data.
-    DownloadRequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send GET download request to '{address}'")]
+    DownloadRequestError { address: String, source: reqwest::Error },
     /// The given download request failed with a non-success status code.
+    #[error("GET download request to '{}' failed with status code {} ({}){}", address, code, code.canonical_reason().unwrap_or("???"), if let Some(message) = message { format!(": {message}") } else { String::new() })]
     DownloadRequestFailure { address: String, code: StatusCode, message: Option<String> },
     /// Failed to reach the next chunk of data.
-    DownloadStreamError { address: String, err: reqwest::Error },
+    #[error("Failed to get next chunk in download stream from '{address}'")]
+    DownloadStreamError { address: String, source: reqwest::Error },
     /// Failed to create the file to which we write the download stream.
-    TarCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create tarball file '{}'", path.display())]
+    TarCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to (re-)open the file to which we've written the download stream.
-    TarOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to re-open tarball file '{}'", path.display())]
+    TarOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the file where we write the download stream.
-    TarWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to tarball file '{}'", path.display())]
+    TarWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to extract the downloaded tar.
-    DataExtractError { err: brane_shr::fs::Error },
+    #[error("Failed to extract dataset")]
+    DataExtractError { source: brane_shr::fs::Error },
     /// Failed to serialize the preprocessrequest.
-    AccessKindSerializeError { err: serde_json::Error },
+    #[error("Failed to serialize the given AccessKind")]
+    AccessKindSerializeError { source: serde_json::Error },
 
     /// Failed to parse the backend file.
-    BackendFileError { err: brane_cfg::backend::Error },
+    #[error("Failed to load backend file")]
+    BackendFileError { source: brane_cfg::backend::Error },
     /// The given backend type is not (yet) supported.
+    #[error("Backend type '{what}' is not (yet) supported")]
     UnsupportedBackend { what: &'static str },
 }
-impl Display for PreprocessError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use self::PreprocessError::*;
-        match self {
-            UnavailableData { name } => write!(f, "{} '{}' is not available locally", name.variant(), name.name()),
-
-            NodeConfigReadError { path, .. } => write!(f, "Failed to load node config file '{}'", path.display()),
-            InfraReadError { path, .. } => write!(f, "Failed to load infrastructure file '{}'", path.display()),
-            UnknownLocationError { loc } => write!(f, "Unknown location '{loc}'"),
-            ProxyError { .. } => write!(f, "Failed to prepare proxy service"),
-            GrpcConnectError { endpoint, .. } => write!(f, "Failed to start gRPC connection with delegate node '{endpoint}'"),
-            GrpcRequestError { what, endpoint, .. } => write!(f, "Failed to send {what} request to delegate node '{endpoint}'"),
-            AccessKindParseError { endpoint, raw, .. } => {
-                write!(f, "Failed to parse access kind '{raw}' sent by remote delegate '{endpoint}'")
-            },
-
-            // KeypairLoadError{ err }                          => write!(f, "Failed to load keypair: {}", err),
-            // StoreLoadError{ err }                            => write!(f, "Failed to load root store: {}", err),
-            // EmptyCertFile{ path }                            => write!(f, "No certificates found in certificate file '{}'", path.display()),
-            // IdentityFileError{ certfile, keyfile, err }      => write!(f, "Failed to parse '{}' and '{}' as a single Identity: {}", certfile.display(), keyfile.display(), err),
-            // RootError{ cafile, err }                         => write!(f, "Failed to parse '{}' as a root certificate: {}", cafile.display(), err),
-            FileReadError { what, path, .. } => write!(f, "Failed to read {} file '{}'", what, path.display()),
-            IdentityFileError { path, .. } => write!(f, "Failed to parse identity file '{}'", path.display()),
-            CertificateError { path, .. } => write!(f, "Failed to parse certificate '{}'", path.display()),
-            LocationResolve { id, .. } => write!(f, "Failed to resolve location ID '{id}' to a local registry address"),
-            DirNotADirError { what, path } => write!(f, "{} directory '{}' is not a directory", what.capitalize(), path.display()),
-            DirNotExistsError { what, path } => write!(f, "{} directory '{}' doesn't exist", what.capitalize(), path.display()),
-            DirRemoveError { what, path, .. } => write!(f, "Failed to remove {} directory '{}'", what, path.display()),
-            DirCreateError { what, path, .. } => write!(f, "Failed to create {} directory '{}'", what, path.display()),
-            ProxyCreateError { address, .. } => write!(f, "Failed to create proxy to '{address}'"),
-            ClientCreateError { .. } => write!(f, "Failed to create HTTP-client"),
-            DownloadRequestError { address, .. } => write!(f, "Failed to send GET download request to '{address}'"),
-            DownloadRequestFailure { address, code, message } => write!(
-                f,
-                "GET download request to '{}' failed with status code {} ({}){}",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(message) = message { format!(": {message}") } else { String::new() }
-            ),
-            DownloadStreamError { address, .. } => write!(f, "Failed to get next chunk in download stream from '{address}'"),
-            TarCreateError { path, .. } => write!(f, "Failed to create tarball file '{}'", path.display()),
-            TarOpenError { path, .. } => write!(f, "Failed to re-open tarball file '{}'", path.display()),
-            TarWriteError { path, .. } => write!(f, "Failed to write to tarball file '{}'", path.display()),
-            DataExtractError { .. } => write!(f, "Failed to extract dataset"),
-            AccessKindSerializeError { .. } => write!(f, "Failed to serialize the given AccessKind"),
-
-            BackendFileError { .. } => write!(f, "Failed to load backend file"),
-            UnsupportedBackend { what } => write!(f, "Backend type '{what}' is not (yet) supported"),
-        }
-    }
-}
-impl Error for PreprocessError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use PreprocessError::*;
-        match self {
-            UnavailableData { .. } => None,
-
-            NodeConfigReadError { err, .. } => Some(err),
-            InfraReadError { err, .. } => Some(err),
-            UnknownLocationError { .. } => None,
-            ProxyError { err } => Some(&**err),
-            GrpcConnectError { err, .. } => Some(err),
-            GrpcRequestError { err, .. } => Some(err),
-            AccessKindParseError { err, .. } => Some(err),
-
-            FileReadError { err, .. } => Some(err),
-            IdentityFileError { err, .. } => Some(err),
-            CertificateError { err, .. } => Some(err),
-            LocationResolve { err, .. } => Some(err),
-            DirNotADirError { .. } => None,
-            DirNotExistsError { .. } => None,
-            DirRemoveError { err, .. } => Some(err),
-            DirCreateError { err, .. } => Some(err),
-            ProxyCreateError { err, .. } => Some(err),
-            ClientCreateError { err } => Some(err),
-            DownloadRequestError { err, .. } => Some(err),
-            DownloadRequestFailure { .. } => None,
-            DownloadStreamError { err, .. } => Some(err),
-            TarCreateError { err, .. } => Some(err),
-            TarOpenError { err, .. } => Some(err),
-            TarWriteError { err, .. } => Some(err),
-            DataExtractError { err } => Some(err),
-            AccessKindSerializeError { err } => Some(err),
-
-            BackendFileError { err } => Some(err),
-            UnsupportedBackend { .. } => None,
-        }
-    }
-}
-
-
 
 /// Defines common errors that occur when trying to execute tasks.
 ///
 /// Note: we've boxed `Image` to reduce the size of the error (and avoid running into `clippy::result_large_err`).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ExecuteError {
     // General errors
     /// We encountered a package call that we didn't know.
+    #[error("Unknown package '{name}' (or it does not have version {version})")]
     UnknownPackage { name: String, version: Version },
     /// We encountered a dataset/result that we didn't know.
+    #[error("Unknown {} '{}'", name.variant(), name.name())]
     UnknownData { name: DataName },
     /// Failed to serialize task's input arguments
-    ArgsEncodeError { err: serde_json::Error },
+    #[error("Failed to serialize input arguments")]
+    ArgsEncodeError { source: serde_json::Error },
     /// The external call failed with a nonzero exit code and some stdout/stderr
+    #[error(
+        "Task '{}' (image '{}') failed with exit code {}\n\n{}\n\n{}\n\n",
+        name,
+        image,
+        code,
+        BlockFormatter::new(stdout),
+        BlockFormatter::new(stderr)
+    )]
     ExternalCallFailed { name: String, image: Box<Image>, code: i32, stdout: String, stderr: String },
     /// Failed to decode the branelet output from base64 to raw bytes
-    Base64DecodeError { raw: String, err: base64::DecodeError },
+    #[error("Failed to decode the following task output as valid Base64:\n{}\n\n", BlockFormatter::new(raw))]
+    Base64DecodeError { raw: String, source: base64::DecodeError },
     /// Failed to decode the branelet output from raw bytes to an UTF-8 string
-    Utf8DecodeError { raw: String, err: std::string::FromUtf8Error },
+    #[error("Failed to decode the following task output as valid UTF-8:\n{}\n\n", BlockFormatter::new(raw))]
+    Utf8DecodeError { raw: String, source: std::string::FromUtf8Error },
     /// Failed to decode the branelet output from an UTF-8 string to a FullValue
-    JsonDecodeError { raw: String, err: serde_json::Error },
+    #[error("Failed to decode the following task output as valid JSON:\n{}\n\n", BlockFormatter::new(raw))]
+    JsonDecodeError { raw: String, source: serde_json::Error },
 
     // Docker errors
     /// Failed to create a new volume bind
-    VolumeBindError { err: specifications::container::VolumeBindError },
+    #[error("Failed to create VolumeBind")]
+    VolumeBindError { source: specifications::container::VolumeBindError },
     /// The generated path of a result is not a directory
+    #[error("Result directory '{}' exists but is not a directory", path.display())]
     ResultDirNotADir { path: PathBuf },
     /// Could not remove the old result directory
-    ResultDirRemoveError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to remove existing result directory '{}'", path.display())]
+    ResultDirRemoveError { path: PathBuf, source: std::io::Error },
     /// Could not create the new result directory
-    ResultDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create result directory '{}'", path.display())]
+    ResultDirCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to run the task as a local Docker container
-    DockerError { name: String, image: Box<Image>, err: DockerError },
+    #[error("Failed to execute task '{name}' (image '{image}') as a Docker container")]
+    DockerError { name: String, image: Box<Image>, source: DockerError },
 
     // Instance-only (client side)
     /// The given job status was missing a string while we expected one
+    #[error("Incoming status update {status:?} is missing mandatory `value` field")]
     StatusEmptyStringError { status: TaskStatus },
     /// Failed to parse the given value as a FullValue
-    StatusValueParseError { status: TaskStatus, raw: String, err: serde_json::Error },
+    #[error("Failed to parse '{raw}' as a FullValue in incoming status update {status:?}")]
+    StatusValueParseError { status: TaskStatus, raw: String, source: serde_json::Error },
     /// Failed to parse the given value as a return code/stdout/stderr triplet.
-    StatusTripletParseError { status: TaskStatus, raw: String, err: serde_json::Error },
+    #[error("Failed to parse '{raw}' as a return code/stdout/stderr triplet in incoming status update {status:?}")]
+    StatusTripletParseError { status: TaskStatus, raw: String, source: serde_json::Error },
     /// Failed to update the client of a status change.
-    ClientUpdateError { status: TaskStatus, err: tokio::sync::mpsc::error::SendError<Result<TaskReply, Status>> },
+    #[error("Failed to update client of status {status:?}")]
+    ClientUpdateError { status: TaskStatus, source: tokio::sync::mpsc::error::SendError<Result<TaskReply, Status>> },
     /// Failed to load the node config file.
-    NodeConfigReadError { path: PathBuf, err: brane_cfg::info::YamlError },
+    #[error("Failed to load node config file '{}'", path.display())]
+    NodeConfigReadError { path: PathBuf, source: brane_cfg::info::YamlError },
     /// Failed to load the infra file.
-    InfraReadError { path: PathBuf, err: brane_cfg::infra::Error },
+    #[error("Failed to load infrastructure file '{}'", path.display())]
+    InfraReadError { path: PathBuf, source: brane_cfg::infra::Error },
     /// The given location was unknown.
+    #[error("Unknown location '{loc}'")]
     UnknownLocationError { loc: Location },
     /// Failed to prepare the proxy service.
-    ProxyError { err: Box<dyn 'static + Send + Sync + Error> },
+    #[error("Failed to prepare proxy service")]
+    ProxyError { source: Box<dyn 'static + Send + Sync + Error> },
     /// Failed to connect to a delegate node with gRPC
-    GrpcConnectError { endpoint: Address, err: specifications::working::Error },
+    #[error("Failed to start gRPC connection with delegate node '{endpoint}'")]
+    GrpcConnectError { endpoint: Address, source: specifications::working::Error },
     /// Failed to send a preprocess request to a delegate node with gRPC
-    GrpcRequestError { what: &'static str, endpoint: Address, err: tonic::Status },
+    #[error("Failed to send {what} request to delegate node '{endpoint}'")]
+    GrpcRequestError { what: &'static str, endpoint: Address, source: tonic::Status },
     /// Preprocessing failed with the following error.
-    ExecuteError { endpoint: Address, name: String, status: TaskStatus, err: StringError },
+    #[error("Remote delegate '{endpoint}' returned status '{status:?}' while executing task '{name}'")]
+    ExecuteError { endpoint: Address, name: String, status: TaskStatus, source: StringError },
 
     // Instance-only (worker side)
     /// Failed to load the digest cache file
-    DigestReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read cached digest in '{}'", path.display())]
+    DigestReadError { path: PathBuf, source: std::io::Error },
     /// Failed to fetch the digest of an already existing image.
-    DigestError { path: PathBuf, err: DockerError },
+    #[error("Failed to read digest of image '{}'", path.display())]
+    DigestError { path: PathBuf, source: DockerError },
     /// Failed to create a reqwest proxy object.
-    ProxyCreateError { address: Address, err: reqwest::Error },
+    #[error("Failed to create proxy to '{address}'")]
+    ProxyCreateError { address: Address, source: reqwest::Error },
     /// Failed to create a reqwest client.
-    ClientCreateError { err: reqwest::Error },
+    #[error("Failed to create HTTP-client")]
+    ClientCreateError { source: reqwest::Error },
     /// Failed to send a GET-request to fetch the data.
-    DownloadRequestError { address: String, err: reqwest::Error },
+    #[error("Failed to send GET download request to '{address}'")]
+    DownloadRequestError { address: String, source: reqwest::Error },
     /// The given download request failed with a non-success status code.
+    #[error("GET download request to '{}' failed with status code {} ({}){}", address, code, code.canonical_reason().unwrap_or("???"), if let Some(message) = message { format!(": {message}") } else { String::new() })]
     DownloadRequestFailure { address: String, code: StatusCode, message: Option<String> },
     /// Failed to reach the next chunk of data.
-    DownloadStreamError { address: String, err: reqwest::Error },
+    #[error("Failed to get next chunk in download stream from '{address}'")]
+    DownloadStreamError { address: String, source: reqwest::Error },
     /// Failed to create the file to which we write the download stream.
-    ImageCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create tarball file '{}'", path.display())]
+    ImageCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the file where we write the download stream.
-    ImageWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to tarball file '{}'", path.display())]
+    ImageWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the file where we write the container ID.
-    IdWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write image ID to file '{}'", path.display())]
+    IdWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to read from the file where we cached the container ID.
-    IdReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read image from file '{}'", path.display())]
+    IdReadError { path: PathBuf, source: std::io::Error },
     /// Failed to hash the given container.
-    HashError { err: DockerError },
+    #[error("Failed to hash image")]
+    HashError { source: DockerError },
     /// Failed to write to the file where we write the container hash.
-    HashWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write image hash to file '{}'", path.display())]
+    HashWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to read to the file where we cached the container hash.
-    HashReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read image hash from file '{}'", path.display())]
+    HashReadError { path: PathBuf, source: std::io::Error },
 
     /// The checker rejected the workflow.
+    #[error("Checker rejected workflow")]
     AuthorizationFailure { checker: Address },
     /// The checker failed to check workflow authorization.
-    AuthorizationError { checker: Address, err: AuthorizeError },
+    #[error("Checker failed to authorize workflow")]
+    AuthorizationError { checker: Address, source: AuthorizeError },
     /// Failed to get an up-to-date package index.
-    PackageIndexError { endpoint: String, err: ApiError },
+    #[error("Failed to get PackageIndex from '{endpoint}'")]
+    PackageIndexError { endpoint: String, source: ApiError },
     /// Failed to load the backend file.
-    BackendFileError { path: PathBuf, err: brane_cfg::backend::Error },
+    #[error("Failed to load backend file '{}'", path.display())]
+    BackendFileError { path: PathBuf, source: brane_cfg::backend::Error },
 }
-impl Display for ExecuteError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use self::ExecuteError::*;
-        match self {
-            UnknownPackage { name, version } => write!(f, "Unknown package '{name}' (or it does not have version {version})"),
-            UnknownData { name } => write!(f, "Unknown {} '{}'", name.variant(), name.name()),
-            ArgsEncodeError { .. } => write!(f, "Failed to serialize input arguments"),
-            ExternalCallFailed { name, image, code, stdout, stderr } => write!(
-                f,
-                "Task '{}' (image '{}') failed with exit code {}\n\n{}\n\n{}\n\n",
-                name,
-                image,
-                code,
-                BlockFormatter::new(stdout),
-                BlockFormatter::new(stderr)
-            ),
-            Base64DecodeError { raw, .. } => {
-                write!(f, "Failed to decode the following task output as valid Base64:\n{}\n\n", BlockFormatter::new(raw))
-            },
-            Utf8DecodeError { raw, .. } => {
-                write!(f, "Failed to decode the following task output as valid UTF-8:\n{}\n\n", BlockFormatter::new(raw))
-            },
-            JsonDecodeError { raw, .. } => {
-                write!(f, "Failed to decode the following task output as valid JSON:\n{}\n\n", BlockFormatter::new(raw))
-            },
-
-            VolumeBindError { .. } => write!(f, "Failed to create VolumeBind"),
-            ResultDirNotADir { path } => write!(f, "Result directory '{}' exists but is not a directory", path.display()),
-            ResultDirRemoveError { path, .. } => write!(f, "Failed to remove existing result directory '{}'", path.display()),
-            ResultDirCreateError { path, .. } => write!(f, "Failed to create result directory '{}'", path.display()),
-            DockerError { name, image, .. } => write!(f, "Failed to execute task '{name}' (image '{image}') as a Docker container"),
-
-            StatusEmptyStringError { status } => write!(f, "Incoming status update {status:?} is missing mandatory `value` field"),
-            StatusValueParseError { status, raw, .. } => {
-                write!(f, "Failed to parse '{raw}' as a FullValue in incoming status update {status:?}")
-            },
-            StatusTripletParseError { status, raw, .. } => {
-                write!(f, "Failed to parse '{raw}' as a return code/stdout/stderr triplet in incoming status update {status:?}")
-            },
-            ClientUpdateError { status, .. } => write!(f, "Failed to update client of status {status:?}"),
-            NodeConfigReadError { path, .. } => write!(f, "Failed to load node config file '{}'", path.display()),
-            InfraReadError { path, .. } => write!(f, "Failed to load infrastructure file '{}'", path.display()),
-            UnknownLocationError { loc } => write!(f, "Unknown location '{loc}'"),
-            ProxyError { .. } => write!(f, "Failed to prepare proxy service"),
-            GrpcConnectError { endpoint, .. } => write!(f, "Failed to start gRPC connection with delegate node '{endpoint}'"),
-            GrpcRequestError { what, endpoint, .. } => write!(f, "Failed to send {what} request to delegate node '{endpoint}'"),
-            ExecuteError { endpoint, name, status, .. } => {
-                write!(f, "Remote delegate '{endpoint}' returned status '{status:?}' while executing task '{name}'")
-            },
-
-            DigestReadError { path, .. } => write!(f, "Failed to read cached digest in '{}'", path.display()),
-            DigestError { path, .. } => write!(f, "Failed to read digest of image '{}'", path.display()),
-            ProxyCreateError { address, .. } => write!(f, "Failed to create proxy to '{address}'"),
-            ClientCreateError { .. } => write!(f, "Failed to create HTTP-client"),
-            DownloadRequestError { address, .. } => write!(f, "Failed to send GET download request to '{address}'"),
-            DownloadRequestFailure { address, code, message } => write!(
-                f,
-                "GET download request to '{}' failed with status code {} ({}){}",
-                address,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(message) = message { format!(": {message}") } else { String::new() }
-            ),
-            DownloadStreamError { address, .. } => write!(f, "Failed to get next chunk in download stream from '{address}'"),
-            ImageCreateError { path, .. } => write!(f, "Failed to create tarball file '{}'", path.display()),
-            ImageWriteError { path, .. } => write!(f, "Failed to write to tarball file '{}'", path.display()),
-            IdWriteError { path, .. } => write!(f, "Failed to write image ID to file '{}'", path.display()),
-            IdReadError { path, .. } => write!(f, "Failed to read image from file '{}'", path.display()),
-            HashError { .. } => write!(f, "Failed to hash image"),
-            HashWriteError { path, .. } => write!(f, "Failed to write image hash to file '{}'", path.display()),
-            HashReadError { path, .. } => write!(f, "Failed to read image hash from file '{}'", path.display()),
-
-            AuthorizationFailure { checker: _ } => write!(f, "Checker rejected workflow"),
-            AuthorizationError { checker: _, .. } => write!(f, "Checker failed to authorize workflow"),
-            PackageIndexError { endpoint, .. } => write!(f, "Failed to get PackageIndex from '{endpoint}'"),
-            BackendFileError { path, .. } => write!(f, "Failed to load backend file '{}'", path.display()),
-        }
-    }
-}
-impl Error for ExecuteError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use self::ExecuteError::*;
-        match self {
-            UnknownPackage { .. } => None,
-            UnknownData { .. } => None,
-            ArgsEncodeError { err } => Some(err),
-            ExternalCallFailed { .. } => None,
-            Base64DecodeError { err, .. } => Some(err),
-            Utf8DecodeError { err, .. } => Some(err),
-            JsonDecodeError { err, .. } => Some(err),
-
-            VolumeBindError { err } => Some(err),
-            ResultDirNotADir { .. } => None,
-            ResultDirRemoveError { err, .. } => Some(err),
-            ResultDirCreateError { err, .. } => Some(err),
-            DockerError { err, .. } => Some(err),
-
-            StatusEmptyStringError { .. } => None,
-            StatusValueParseError { err, .. } => Some(err),
-            StatusTripletParseError { err, .. } => Some(err),
-            ClientUpdateError { err, .. } => Some(err),
-            NodeConfigReadError { err, .. } => Some(err),
-            InfraReadError { err, .. } => Some(err),
-            UnknownLocationError { .. } => None,
-            ProxyError { err } => Some(&**err),
-            GrpcConnectError { err, .. } => Some(err),
-            GrpcRequestError { err, .. } => Some(err),
-
-            DigestReadError { err, .. } => Some(err),
-            DigestError { err, .. } => Some(err),
-            ProxyCreateError { err, .. } => Some(err),
-            ClientCreateError { err } => Some(err),
-            DownloadRequestError { err, .. } => Some(err),
-            DownloadRequestFailure { .. } => None,
-            DownloadStreamError { err, .. } => Some(err),
-            ImageCreateError { err, .. } => Some(err),
-            ImageWriteError { err, .. } => Some(err),
-            IdWriteError { err, .. } => Some(err),
-            IdReadError { err, .. } => Some(err),
-            HashError { err } => Some(err),
-            HashWriteError { err, .. } => Some(err),
-            HashReadError { err, .. } => Some(err),
-
-            AuthorizationFailure { .. } => None,
-            AuthorizationError { err, .. } => Some(err),
-            PackageIndexError { err, .. } => Some(err),
-            BackendFileError { err, .. } => Some(err),
-            ExecuteError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// A special case of the execute error, this relates to authorization errors in the backend eFLINT reasoner (or other reasoners).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum AuthorizeError {
     /// Failed to generate a new JWT for a request.
-    TokenGenerate { secret: PathBuf, err: specifications::policy::Error },
+    #[error("Failed to generate new JWT using secret '{}'", secret.display())]
+    TokenGenerate { secret: PathBuf, source: specifications::policy::Error },
     /// Failed to build a `reqwest::Client`.
-    ClientBuild { err: reqwest::Error },
+    #[error("Failed to build HTTP client")]
+    ClientBuild { source: reqwest::Error },
     /// Failed to build a request to the policy reasoner.
-    ExecuteRequestBuild { addr: String, err: reqwest::Error },
+    #[error("Failed to build an ExecuteRequest destined for the checker at '{addr}'")]
+    ExecuteRequestBuild { addr: String, source: reqwest::Error },
     /// Failed to send a request to the policy reasoner.
-    ExecuteRequestSend { addr: String, err: reqwest::Error },
+    #[error("Failed to send ExecuteRequest to checker '{addr}'")]
+    ExecuteRequestSend { addr: String, source: reqwest::Error },
     /// Request did not succeed
+    #[error("ExecuteRequest to checker '{}' failed with status code {} ({}){}", addr, code, code.canonical_reason().unwrap_or("???"), if let Some(err) = err { format!("\n\nResponse:\n{}\n{}\n{}\n", (0..80).map(|_| '-').collect::<String>(), err, (0..80).map(|_| '-').collect::<String>()) } else { String::new() })]
     ExecuteRequestFailure { addr: String, code: StatusCode, err: Option<String> },
     /// Failed to download the body of an execute request response.
-    ExecuteBodyDownload { addr: String, err: reqwest::Error },
+    #[error("Failed to download response body from '{addr}'")]
+    ExecuteBodyDownload { addr: String, source: reqwest::Error },
     /// Failed to deserialize the body of an execute request response.
-    ExecuteBodyDeserialize { addr: String, raw: String, err: serde_json::Error },
+    #[error("Failed to deserialize response body received from '{}' as valid JSON\n\nResponse:\n{}\n", addr, BlockFormatter::new(raw))]
+    ExecuteBodyDeserialize { addr: String, raw: String, source: serde_json::Error },
 
     /// The data to authorize is not input to the task given as context.
+    #[error("Dataset '{data_name}' is not an input to task {pc}")]
     AuthorizationDataMismatch { pc: ProgramCounter, data_name: DataName },
     /// The user to authorize does not execute the given task.
+    #[error("Authorized user '{}' does not match '{}' user in workflow\n\nWorkflow:\n{:#?}\n", authenticated, who, workflow)]
     AuthorizationUserMismatch { who: String, authenticated: String, workflow: Workflow },
     /// An edge was referenced to be executed which wasn't an [`Edge::Node`](brane_ast::ast::Edge).
+    #[error("Edge {pc} in workflow is not an Edge::Node but an Edge::{got}")]
     AuthorizationWrongEdge { pc: ProgramCounter, got: String },
     /// An edge index given was out-of-bounds for the given function.
+    #[error("Edge index {got} is out-of-bounds for function {func} with {max} edges")]
     IllegalEdgeIdx { func: FunctionId, got: usize, max: usize },
     /// A given function does not exist
+    #[error("Function {got} does not exist in given workflow")]
     IllegalFuncId { got: FunctionId },
     /// There was a node in a workflow with no `at`-specified.
+    #[error("Node call at {pc} has no location planned")]
     MissingLocation { pc: ProgramCounter },
     /// The workflow has no end user specified.
+    #[error("Given workflow has no end user specified\n\nWorkflow:\n{}\n", BlockFormatter::new(workflow))]
     NoWorkflowUser { workflow: String },
 }
-impl Display for AuthorizeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use AuthorizeError::*;
-        match self {
-            TokenGenerate { secret, .. } => write!(f, "Failed to generate new JWT using secret '{}'", secret.display()),
-            ClientBuild { .. } => write!(f, "Failed to build HTTP client"),
-            ExecuteRequestBuild { addr, .. } => write!(f, "Failed to build an ExecuteRequest destined for the checker at '{addr}'"),
-            ExecuteRequestSend { addr, .. } => write!(f, "Failed to send ExecuteRequest to checker '{addr}'"),
-            ExecuteRequestFailure { addr, code, err } => write!(
-                f,
-                "ExecuteRequest to checker '{}' failed with status code {} ({}){}",
-                addr,
-                code,
-                code.canonical_reason().unwrap_or("???"),
-                if let Some(err) = err {
-                    format!("\n\nResponse:\n{}\n{}\n{}\n", (0..80).map(|_| '-').collect::<String>(), err, (0..80).map(|_| '-').collect::<String>())
-                } else {
-                    String::new()
-                }
-            ),
-            ExecuteBodyDownload { addr, .. } => write!(f, "Failed to download response body from '{addr}'"),
-            ExecuteBodyDeserialize { addr, raw, .. } => {
-                write!(f, "Failed to deserialize response body received from '{}' as valid JSON\n\nResponse:\n{}\n", addr, BlockFormatter::new(raw))
-            },
-
-            AuthorizationDataMismatch { pc, data_name } => write!(f, "Dataset '{data_name}' is not an input to task {pc}"),
-            AuthorizationUserMismatch { who, authenticated, workflow } => {
-                write!(f, "Authorized user '{}' does not match '{}' user in workflow\n\nWorkflow:\n{:#?}\n", authenticated, who, workflow)
-            },
-            AuthorizationWrongEdge { pc, got } => write!(f, "Edge {pc} in workflow is not an Edge::Node but an Edge::{got}"),
-            IllegalEdgeIdx { func, got, max } => write!(f, "Edge index {got} is out-of-bounds for function {func} with {max} edges"),
-            IllegalFuncId { got } => write!(f, "Function {got} does not exist in given workflow"),
-            MissingLocation { pc } => write!(f, "Node call at {pc} has no location planned"),
-            NoWorkflowUser { workflow } => write!(f, "Given workflow has no end user specified\n\nWorkflow:\n{}\n", BlockFormatter::new(workflow)),
-        }
-    }
-}
-impl Error for AuthorizeError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use AuthorizeError::*;
-        match self {
-            TokenGenerate { err, .. } => Some(err),
-            ClientBuild { err, .. } => Some(err),
-            ExecuteRequestBuild { err, .. } => Some(err),
-            ExecuteRequestSend { err, .. } => Some(err),
-            ExecuteRequestFailure { .. } => None,
-            ExecuteBodyDownload { err, .. } => Some(err),
-            ExecuteBodyDeserialize { err, .. } => Some(err),
-
-            AuthorizationDataMismatch { .. } => None,
-            AuthorizationUserMismatch { .. } => None,
-            AuthorizationWrongEdge { .. } => None,
-            IllegalEdgeIdx { .. } => None,
-            IllegalFuncId { .. } => None,
-            MissingLocation { .. } => None,
-            NoWorkflowUser { .. } => None,
-        }
-    }
-}
-
-
 
 /// Defines common errors that occur when trying to write to stdout.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum StdoutError {
     /// Failed to write to the gRPC channel to feedback stdout back to the client.
-    TxWriteError { err: tokio::sync::mpsc::error::SendError<Result<ExecuteReply, Status>> },
+    #[error("Failed to write on gRPC channel back to client")]
+    TxWriteError { source: tokio::sync::mpsc::error::SendError<Result<ExecuteReply, Status>> },
 }
-impl Display for StdoutError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use StdoutError::*;
-        match self {
-            TxWriteError { .. } => write!(f, "Failed to write on gRPC channel back to client"),
-        }
-    }
-}
-impl Error for StdoutError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use StdoutError::*;
-        match self {
-            TxWriteError { err } => Some(err),
-        }
-    }
-}
-
-
 
 /// Defines common errors that occur when trying to commit an intermediate result.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CommitError {
     // Docker-local errors
     /// The given dataset was unavailable locally
+    #[error("Dataset '{}' is unavailable{}", name, if !locs.is_empty() { format!( "; however, locations {} do (try to get download permission to those datasets)", locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")) } else { String::new() })]
     UnavailableDataError { name: String, locs: Vec<String> },
     /// The generated path of a data is not a directory
+    #[error("Dataset directory '{}' exists but is not a directory", path.display())]
     DataDirNotADir { path: PathBuf },
     /// Could not create the new data directory
-    DataDirCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create dataset directory '{}'", path.display())]
+    DataDirCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to create a new DataInfo file.
-    DataInfoCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create new data info file '{}'", path.display())]
+    DataInfoCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to serialize a new DataInfo file.
-    DataInfoSerializeError { err: serde_yaml::Error },
+    #[error("Failed to serialize DataInfo struct")]
+    DataInfoSerializeError { source: serde_yaml::Error },
     /// Failed to write the DataInfo the the created file.
-    DataInfoWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write DataInfo to '{}'", path.display())]
+    DataInfoWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to read the given directory.
-    DirReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read directory '{}'", path.display())]
+    DirReadError { path: PathBuf, source: std::io::Error },
     /// Failed to read the given directory entry.
-    DirEntryReadError { path: PathBuf, i: usize, err: std::io::Error },
+    #[error("Failed to read entry {} in directory '{}'", i, path.display())]
+    DirEntryReadError { path: PathBuf, i: usize, source: std::io::Error },
     /// Failed to copy the data
-    DataCopyError { err: brane_shr::fs::Error },
+    #[error("Failed to copy data directory")]
+    DataCopyError { source: brane_shr::fs::Error },
 
     // Instance-only (client side)
     /// Failed to load the node config file.
-    NodeConfigReadError { path: PathBuf, err: brane_cfg::info::YamlError },
+    #[error("Failed to load node config file '{}'", path.display())]
+    NodeConfigReadError { path: PathBuf, source: brane_cfg::info::YamlError },
     /// Failed to load the infra file.
-    InfraReadError { path: PathBuf, err: brane_cfg::infra::Error },
+    #[error("Failed to load infrastructure file '{}'", path.display())]
+    InfraReadError { path: PathBuf, source: brane_cfg::infra::Error },
     /// The given location was unknown.
+    #[error("Unknown location '{loc}'")]
     UnknownLocationError { loc: Location },
     /// Failed to prepare the proxy service.
-    ProxyError { err: Box<dyn 'static + Send + Sync + Error> },
+    #[error("Failed to prepare proxy service")]
+    ProxyError { source: Box<dyn 'static + Send + Sync + Error> },
     /// Failed to connect to a delegate node with gRPC
-    GrpcConnectError { endpoint: Address, err: specifications::working::Error },
+    #[error("Failed to start gRPC connection with delegate node '{endpoint}'")]
+    GrpcConnectError { endpoint: Address, source: specifications::working::Error },
     /// Failed to send a preprocess request to a delegate node with gRPC
-    GrpcRequestError { what: &'static str, endpoint: Address, err: tonic::Status },
+    #[error("Failed to send {what} request to delegate node '{endpoint}'")]
+    GrpcRequestError { what: &'static str, endpoint: Address, source: tonic::Status },
 
     // Instance-only (worker side)
     /// Failed to read the AssetInfo file.
-    AssetInfoReadError { path: PathBuf, err: specifications::data::AssetInfoError },
+    #[error("Failed to load asset info file '{}'", path.display())]
+    AssetInfoReadError { path: PathBuf, source: specifications::data::AssetInfoError },
     /// Failed to remove a file.
-    FileRemoveError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to remove file '{}'", path.display())]
+    FileRemoveError { path: PathBuf, source: std::io::Error },
     /// Failed to remove a directory.
-    DirRemoveError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to remove directory '{}'", path.display())]
+    DirRemoveError { path: PathBuf, source: std::io::Error },
     /// A given path is neither a file nor a directory.
+    #[error("Given path '{}' neither points to a file nor a directory", path.display())]
     PathNotFileNotDir { path: PathBuf },
 }
-impl Display for CommitError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use self::CommitError::*;
-        match self {
-            UnavailableDataError { name, locs } => write!(
-                f,
-                "Dataset '{}' is unavailable{}",
-                name,
-                if !locs.is_empty() {
-                    format!(
-                        "; however, locations {} do (try to get download permission to those datasets)",
-                        locs.iter().map(|l| format!("'{l}'")).collect::<Vec<String>>().join(", ")
-                    )
-                } else {
-                    String::new()
-                }
-            ),
-            DataDirNotADir { path } => write!(f, "Dataset directory '{}' exists but is not a directory", path.display()),
-            DataDirCreateError { path, .. } => write!(f, "Failed to create dataset directory '{}'", path.display()),
-            DataInfoCreateError { path, .. } => write!(f, "Failed to create new data info file '{}'", path.display()),
-            DataInfoSerializeError { .. } => write!(f, "Failed to serialize DataInfo struct"),
-            DataInfoWriteError { path, .. } => write!(f, "Failed to write DataInfo to '{}'", path.display()),
-            DirReadError { path, .. } => write!(f, "Failed to read directory '{}'", path.display()),
-            DirEntryReadError { path, i, .. } => write!(f, "Failed to read entry {} in directory '{}'", i, path.display()),
-            DataCopyError { .. } => write!(f, "Failed to copy data directory"),
-
-            NodeConfigReadError { path, .. } => write!(f, "Failed to load node config file '{}'", path.display()),
-            InfraReadError { path, .. } => write!(f, "Failed to load infrastructure file '{}'", path.display()),
-            UnknownLocationError { loc } => write!(f, "Unknown location '{loc}'"),
-            ProxyError { .. } => write!(f, "Failed to prepare proxy service"),
-            GrpcConnectError { endpoint, .. } => write!(f, "Failed to start gRPC connection with delegate node '{endpoint}'"),
-            GrpcRequestError { what, endpoint, .. } => write!(f, "Failed to send {what} request to delegate node '{endpoint}'"),
-
-            AssetInfoReadError { path, .. } => write!(f, "Failed to load asset info file '{}'", path.display()),
-            FileRemoveError { path, .. } => write!(f, "Failed to remove file '{}'", path.display()),
-            DirRemoveError { path, .. } => write!(f, "Failed to remove directory '{}'", path.display()),
-            PathNotFileNotDir { path } => write!(f, "Given path '{}' neither points to a file nor a directory", path.display()),
-        }
-    }
-}
-impl Error for CommitError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use CommitError::*;
-        match self {
-            UnavailableDataError { .. } => None,
-            DataDirNotADir { .. } => None,
-            DataDirCreateError { err, .. } => Some(err),
-            DataInfoCreateError { err, .. } => Some(err),
-            DataInfoSerializeError { err } => Some(err),
-            DataInfoWriteError { err, .. } => Some(err),
-            DirReadError { err, .. } => Some(err),
-            DirEntryReadError { err, .. } => Some(err),
-            DataCopyError { err } => Some(err),
-
-            NodeConfigReadError { err, .. } => Some(err),
-            InfraReadError { err, .. } => Some(err),
-            UnknownLocationError { .. } => None,
-            ProxyError { err } => Some(&**err),
-            GrpcConnectError { err, .. } => Some(err),
-            GrpcRequestError { err, .. } => Some(err),
-
-            AssetInfoReadError { err, .. } => Some(err),
-            FileRemoveError { err, .. } => Some(err),
-            DirRemoveError { err, .. } => Some(err),
-            PathNotFileNotDir { .. } => None,
-        }
-    }
-}
-
-
 
 /// Collects errors that relate to the AppId or TaskId (actually only parser errors).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum IdError {
     /// Failed to parse the AppId from a string.
-    ParseError { what: &'static str, raw: String, err: uuid::Error },
+    #[error("Failed to parse {what} from '{raw}'")]
+    ParseError { what: &'static str, raw: String, source: uuid::Error },
 }
-impl Display for IdError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use IdError::*;
-        match self {
-            ParseError { what, raw, .. } => write!(f, "Failed to parse {what} from '{raw}'"),
-        }
-    }
-}
-impl Error for IdError {
-    #[inline]
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use IdError::*;
-        match self {
-            ParseError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors that relate to Docker.
 ///
 /// Note: we've boxed `Image` to reduce the size of the error (and avoid running into `clippy::result_large_err`).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DockerError {
     /// We failed to connect to the local Docker daemon.
-    ConnectionError { path: PathBuf, version: ClientVersion, err: bollard::errors::Error },
+    #[error("Failed to connect to the local Docker daemon through socket '{}' and with client version {}", path.display(), version)]
+    ConnectionError { path: PathBuf, version: ClientVersion, source: bollard::errors::Error },
 
     /// Failed to wait for the container with the given name.
-    WaitError { name: String, err: bollard::errors::Error },
+    #[error("Failed to wait for Docker container with name '{name}'")]
+    WaitError { name: String, source: bollard::errors::Error },
     /// Failed to read the logs of a container.
-    LogsError { name: String, err: bollard::errors::Error },
+    #[error("Failed to get logs of Docker container with name '{name}'")]
+    LogsError { name: String, source: bollard::errors::Error },
 
     /// Failed to inspect the given container.
-    InspectContainerError { name: String, err: bollard::errors::Error },
+    #[error("Failed to inspect Docker container with name '{name}'")]
+    InspectContainerError { name: String, source: bollard::errors::Error },
     /// The given container was not attached to any networks.
+    #[error("Docker container with name '{name}' is not connected to any networks")]
     ContainerNoNetwork { name: String },
 
     /// Could not create and/or start the given container.
-    CreateContainerError { name: String, image: Box<Image>, err: bollard::errors::Error },
+    #[error("Could not create Docker container with name '{name}' (image: {image})")]
+    CreateContainerError { name: String, image: Box<Image>, source: bollard::errors::Error },
     /// Fialed to start the given container.
-    StartError { name: String, image: Box<Image>, err: bollard::errors::Error },
+    #[error("Could not start Docker container with name '{name}' (image: {image})")]
+    StartError { name: String, image: Box<Image>, source: bollard::errors::Error },
 
     /// An executing container had no execution state (it wasn't started?)
+    #[error("Docker container with name '{name}' has no execution state (has it been started?)")]
     ContainerNoState { name: String },
     /// An executing container had no return code.
+    #[error("Docker container with name '{name}' has no return code (did you wait before completing?)")]
     ContainerNoExitCode { name: String },
 
     /// Failed to remove the given container.
-    ContainerRemoveError { name: String, err: bollard::errors::Error },
+    #[error("Fialed to remove Docker container with name '{name}'")]
+    ContainerRemoveError { name: String, source: bollard::errors::Error },
 
     /// Failed to open the given image file.
-    ImageFileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open image file '{}'", path.display())]
+    ImageFileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to import the given image file.
-    ImageImportError { path: PathBuf, err: bollard::errors::Error },
+    #[error("Failed to import image file '{}' into Docker engine", path.display())]
+    ImageImportError { path: PathBuf, source: bollard::errors::Error },
     /// Failed to create the given image file.
-    ImageFileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create image file '{}'", path.display())]
+    ImageFileCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to download a piece of the image from the Docker client.
-    ImageExportError { name: String, err: bollard::errors::Error },
+    #[error("Failed to export image '{name}'")]
+    ImageExportError { name: String, source: bollard::errors::Error },
     /// Failed to write a chunk of the exported image.
-    ImageFileWriteError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to write to image file '{}'", path.display())]
+    ImageFileWriteError { path: PathBuf, source: std::io::Error },
     /// Failed to shutdown the given file.
-    ImageFileShutdownError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to shut image file '{}' down", path.display())]
+    ImageFileShutdownError { path: PathBuf, source: std::io::Error },
 
     /// Failed to pull the given image file.
-    ImagePullError { source: String, err: bollard::errors::Error },
+    #[error("Failed to pull image '{source}' into Docker engine")]
+    ImagePullError { image_source: String, source: bollard::errors::Error },
     /// Failed to appropriately tag the pulled image.
-    ImageTagError { image: Box<Image>, source: String, err: bollard::errors::Error },
+    #[error("Failed to tag pulled image '{source}' as '{image}'")]
+    ImageTagError { image: Box<Image>, image_source: String, source: bollard::errors::Error },
 
     /// Failed to inspect a certain image.
-    ImageInspectError { image: Box<Image>, err: bollard::errors::Error },
+    #[error("Failed to inspect image '{}'{}", image.name(), if let Some(digest) = image.digest() { format!(" ({digest})") } else { String::new() })]
+    ImageInspectError { image: Box<Image>, source: bollard::errors::Error },
     /// Failed to remove a certain image.
-    ImageRemoveError { image: Box<Image>, id: String, err: bollard::errors::Error },
+    #[error("Failed to remove image '{}' (id: {}) from Docker engine", image.name(), id)]
+    ImageRemoveError { image: Box<Image>, id: String, source: bollard::errors::Error },
 
     /// Could not open the given image.tar.
-    ImageTarOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Could not open given Docker image file '{}'", path.display())]
+    ImageTarOpenError { path: PathBuf, source: std::io::Error },
     /// Could not read from the given image.tar.
-    ImageTarReadError { path: PathBuf, err: std::io::Error },
+    #[error("Could not read given Docker image file '{}'", path.display())]
+    ImageTarReadError { path: PathBuf, source: std::io::Error },
     /// Could not get the list of entries from the given image.tar.
-    ImageTarEntriesError { path: PathBuf, err: std::io::Error },
+    #[error("Could not get file entries in Docker image file '{}'", path.display())]
+    ImageTarEntriesError { path: PathBuf, source: std::io::Error },
     /// COuld not read a single entry from the given image.tar.
-    ImageTarEntryError { path: PathBuf, err: std::io::Error },
+    #[error("Could not get file entry from Docker image file '{}'", path.display())]
+    ImageTarEntryError { path: PathBuf, source: std::io::Error },
     /// Could not get path from entry
-    ImageTarIllegalPath { path: PathBuf, err: std::io::Error },
+    #[error("Given Docker image file '{}' contains illegal path entry", path.display())]
+    ImageTarIllegalPath { path: PathBuf, source: std::io::Error },
     /// Could not read the manifest.json file
-    ImageTarManifestReadError { path: PathBuf, entry: PathBuf, err: std::io::Error },
+    #[error("Failed to read '{}' in Docker image file '{}'", entry.display(), path.display())]
+    ImageTarManifestReadError { path: PathBuf, entry: PathBuf, source: std::io::Error },
     /// Could not parse the manifest.json file
-    ImageTarManifestParseError { path: PathBuf, entry: PathBuf, err: serde_json::Error },
+    #[error("Could not parse '{}' in Docker image file '{}'", entry.display(), path.display())]
+    ImageTarManifestParseError { path: PathBuf, entry: PathBuf, source: serde_json::Error },
     /// Incorrect number of items found in the toplevel list of the manifest.json file
+    #[error("Got incorrect number of entries in '{}' in Docker image file '{}': got {}, expected 1", entry.display(), path.display(), got)]
     ImageTarIllegalManifestNum { path: PathBuf, entry: PathBuf, got: usize },
     /// Could not find the expected part of the config digest
+    #[error("Found image digest '{}' in '{}' in Docker image file '{}' is illegal: does not start with '{}'", digest, entry.display(), path.display(), crate::docker::MANIFEST_CONFIG_PREFIX)]
     ImageTarIllegalDigest { path: PathBuf, entry: PathBuf, digest: String },
     /// Could not find the manifest.json file in the given image.tar.
+    #[error("Could not find manifest.json in given Docker image file '{}'", path.display())]
     ImageTarNoManifest { path: PathBuf },
 }
-impl Display for DockerError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DockerError::*;
-        match self {
-            ConnectionError { path, version, .. } => {
-                write!(f, "Failed to connect to the local Docker daemon through socket '{}' and with client version {}", path.display(), version)
-            },
-
-            WaitError { name, .. } => write!(f, "Failed to wait for Docker container with name '{name}'"),
-            LogsError { name, .. } => write!(f, "Failed to get logs of Docker container with name '{name}'"),
-
-            InspectContainerError { name, .. } => write!(f, "Failed to inspect Docker container with name '{name}'"),
-            ContainerNoNetwork { name } => write!(f, "Docker container with name '{name}' is not connected to any networks"),
-
-            CreateContainerError { name, image, .. } => write!(f, "Could not create Docker container with name '{name}' (image: {image})"),
-            StartError { name, image, .. } => write!(f, "Could not start Docker container with name '{name}' (image: {image})"),
-
-            ContainerNoState { name } => write!(f, "Docker container with name '{name}' has no execution state (has it been started?)"),
-            ContainerNoExitCode { name } => write!(f, "Docker container with name '{name}' has no return code (did you wait before completing?)"),
-
-            ContainerRemoveError { name, .. } => write!(f, "Fialed to remove Docker container with name '{name}'"),
-
-            ImageFileOpenError { path, .. } => write!(f, "Failed to open image file '{}'", path.display()),
-            ImageImportError { path, .. } => write!(f, "Failed to import image file '{}' into Docker engine", path.display()),
-            ImageFileCreateError { path, .. } => write!(f, "Failed to create image file '{}'", path.display()),
-            ImageExportError { name, .. } => write!(f, "Failed to export image '{name}'"),
-            ImageFileWriteError { path, .. } => write!(f, "Failed to write to image file '{}'", path.display()),
-            ImageFileShutdownError { path, .. } => write!(f, "Failed to shut image file '{}' down", path.display()),
-
-            ImagePullError { source, .. } => write!(f, "Failed to pull image '{source}' into Docker engine"),
-            ImageTagError { image, source, .. } => write!(f, "Failed to tag pulled image '{source}' as '{image}'"),
-
-            ImageInspectError { image, .. } => write!(
-                f,
-                "Failed to inspect image '{}'{}",
-                image.name(),
-                if let Some(digest) = image.digest() { format!(" ({digest})") } else { String::new() }
-            ),
-            ImageRemoveError { image, id, .. } => write!(f, "Failed to remove image '{}' (id: {}) from Docker engine", image.name(), id),
-
-            ImageTarOpenError { path, .. } => write!(f, "Could not open given Docker image file '{}'", path.display()),
-            ImageTarReadError { path, .. } => write!(f, "Could not read given Docker image file '{}'", path.display()),
-            ImageTarEntriesError { path, .. } => write!(f, "Could not get file entries in Docker image file '{}'", path.display()),
-            ImageTarEntryError { path, .. } => write!(f, "Could not get file entry from Docker image file '{}'", path.display()),
-            ImageTarNoManifest { path } => write!(f, "Could not find manifest.json in given Docker image file '{}'", path.display()),
-            ImageTarManifestReadError { path, entry, .. } => {
-                write!(f, "Failed to read '{}' in Docker image file '{}'", entry.display(), path.display())
-            },
-            ImageTarManifestParseError { path, entry, .. } => {
-                write!(f, "Could not parse '{}' in Docker image file '{}'", entry.display(), path.display())
-            },
-            ImageTarIllegalManifestNum { path, entry, got } => write!(
-                f,
-                "Got incorrect number of entries in '{}' in Docker image file '{}': got {}, expected 1",
-                entry.display(),
-                path.display(),
-                got
-            ),
-            ImageTarIllegalDigest { path, entry, digest } => write!(
-                f,
-                "Found image digest '{}' in '{}' in Docker image file '{}' is illegal: does not start with '{}'",
-                digest,
-                entry.display(),
-                path.display(),
-                crate::docker::MANIFEST_CONFIG_PREFIX
-            ),
-            ImageTarIllegalPath { path, .. } => write!(f, "Given Docker image file '{}' contains illegal path entry", path.display()),
-        }
-    }
-}
-impl Error for DockerError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use DockerError::*;
-        match self {
-            ConnectionError { err, .. } => Some(err),
-
-            WaitError { err, .. } => Some(err),
-            LogsError { err, .. } => Some(err),
-
-            InspectContainerError { err, .. } => Some(err),
-            ContainerNoNetwork { .. } => None,
-
-            CreateContainerError { err, .. } => Some(err),
-            StartError { err, .. } => Some(err),
-
-            ContainerNoState { .. } => None,
-            ContainerNoExitCode { .. } => None,
-
-            ContainerRemoveError { err, .. } => Some(err),
-
-            ImageFileOpenError { err, .. } => Some(err),
-            ImageImportError { err, .. } => Some(err),
-            ImageFileCreateError { err, .. } => Some(err),
-            ImageExportError { err, .. } => Some(err),
-            ImageFileWriteError { err, .. } => Some(err),
-            ImageFileShutdownError { err, .. } => Some(err),
-
-            ImagePullError { err, .. } => Some(err),
-            ImageTagError { err, .. } => Some(err),
-
-            ImageInspectError { err, .. } => Some(err),
-            ImageRemoveError { err, .. } => Some(err),
-
-            ImageTarOpenError { err, .. } => Some(err),
-            ImageTarReadError { err, .. } => Some(err),
-            ImageTarEntriesError { err, .. } => Some(err),
-            ImageTarEntryError { err, .. } => Some(err),
-            ImageTarIllegalPath { err, .. } => Some(err),
-            ImageTarManifestReadError { err, .. } => Some(err),
-            ImageTarManifestParseError { err, .. } => Some(err),
-            ImageTarIllegalManifestNum { .. } => None,
-            ImageTarIllegalDigest { .. } => None,
-            ImageTarNoManifest { .. } => None,
-        }
-    }
-}
-
-
 
 /// Collects errors that relate to local index interaction.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LocalError {
     /// There was an error reading entries from a package's directory
-    PackageDirReadError { path: PathBuf, err: std::io::Error },
+    #[error("Could not read package directory '{}'", path.display())]
+    PackageDirReadError { path: PathBuf, source: std::io::Error },
     /// Found a version entry who's path could not be split into a filename
+    #[error("Could not get the version directory from '{}'", path.display())]
     UnreadableVersionEntry { path: PathBuf },
     /// The name of version directory in a package's dir is not a valid version
-    IllegalVersionEntry { package: String, version: String, err: specifications::version::ParseError },
+    #[error("Entry '{version}' for package '{package}' is not a valid version")]
+    IllegalVersionEntry { package: String, version: String, source: specifications::version::ParseError },
     /// The given package has no versions registered to it
+    #[error("Package '{package}' does not have any registered versions")]
     NoVersions { package: String },
 
     /// There was an error reading entries from the packages directory
-    PackagesDirReadError { path: PathBuf, err: std::io::Error },
+    #[error("Could not read from Brane packages directory '{}'", path.display())]
+    PackagesDirReadError { path: PathBuf, source: std::io::Error },
     /// We tried to load a package YML but failed
-    InvalidPackageYml { package: String, path: PathBuf, err: specifications::package::PackageInfoError },
+    #[error("Could not read '{}' for package '{}'", path.display(), package)]
+    InvalidPackageYml { package: String, path: PathBuf, source: specifications::package::PackageInfoError },
     /// We tried to load a Package Index from a JSON value with PackageInfos but we failed
-    PackageIndexError { err: specifications::package::PackageIndexError },
+    #[error("Could not create PackageIndex")]
+    PackageIndexError { source: specifications::package::PackageIndexError },
 
     /// Failed to read the datasets folder
-    DatasetsReadError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to read datasets folder '{}'", path.display())]
+    DatasetsReadError { path: PathBuf, source: std::io::Error },
     /// Failed to open a data.yml file.
-    DataInfoOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open data info file '{}'", path.display())]
+    DataInfoOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read/parse a data.yml file.
-    DataInfoReadError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to read/parse data info file '{}'", path.display())]
+    DataInfoReadError { path: PathBuf, source: serde_yaml::Error },
     /// Failed to create a new DataIndex from the infos locally read.
-    DataIndexError { err: specifications::data::DataIndexError },
+    #[error("Failed to create data index from local datasets")]
+    DataIndexError { source: specifications::data::DataIndexError },
 }
-impl Display for LocalError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use LocalError::*;
-        match self {
-            PackageDirReadError { path, .. } => write!(f, "Could not read package directory '{}'", path.display()),
-            UnreadableVersionEntry { path } => write!(f, "Could not get the version directory from '{}'", path.display()),
-            IllegalVersionEntry { package, version, .. } => write!(f, "Entry '{version}' for package '{package}' is not a valid version"),
-            NoVersions { package } => write!(f, "Package '{package}' does not have any registered versions"),
-
-            PackagesDirReadError { path, .. } => write!(f, "Could not read from Brane packages directory '{}'", path.display()),
-            InvalidPackageYml { package, path, .. } => write!(f, "Could not read '{}' for package '{}'", path.display(), package),
-            PackageIndexError { .. } => write!(f, "Could not create PackageIndex"),
-
-            DatasetsReadError { path, .. } => write!(f, "Failed to read datasets folder '{}'", path.display()),
-            DataInfoOpenError { path, .. } => write!(f, "Failed to open data info file '{}'", path.display()),
-            DataInfoReadError { path, .. } => write!(f, "Failed to read/parse data info file '{}'", path.display()),
-            DataIndexError { .. } => write!(f, "Failed to create data index from local datasets"),
-        }
-    }
-}
-impl Error for LocalError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use LocalError::*;
-        match self {
-            PackageDirReadError { err, .. } => Some(err),
-            UnreadableVersionEntry { .. } => None,
-            IllegalVersionEntry { err, .. } => Some(err),
-            NoVersions { .. } => None,
-
-            PackagesDirReadError { err, .. } => Some(err),
-            InvalidPackageYml { err, .. } => Some(err),
-            PackageIndexError { err } => Some(err),
-
-            DatasetsReadError { err, .. } => Some(err),
-            DataInfoOpenError { err, .. } => Some(err),
-            DataInfoReadError { err, .. } => Some(err),
-            DataIndexError { err } => Some(err),
-        }
-    }
-}
-
-
 
 /// Collects errors that relate to API interaction.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ApiError {
     /// Failed to send a GraphQL request.
-    RequestError { address: String, err: reqwest::Error },
+    #[error("Failed to post request to '{address}'")]
+    RequestError { address: String, source: reqwest::Error },
     /// Failed to get the body of a response.
-    ResponseBodyError { address: String, err: reqwest::Error },
+    #[error("Failed to get body from response from '{address}'")]
+    ResponseBodyError { address: String, source: reqwest::Error },
     /// Failed to parse the response from the server.
-    ResponseJsonParseError { address: String, raw: String, err: serde_json::Error },
+    #[error("Failed to parse response \"\"\"{raw}\"\"\" from '{address}' as JSON")]
+    ResponseJsonParseError { address: String, raw: String, source: serde_json::Error },
     /// The remote failed to produce even a single result (not even 'no packages').
+    #[error("'{address}' responded without a body (not even that no packages are available)")]
     NoResponse { address: String },
 
     /// Failed to parse the package kind in a package info.
-    PackageKindParseError { address: String, index: usize, raw: String, err: specifications::package::PackageKindError },
+    #[error("Failed to parse '{raw}' as package kind in package {index} returned by '{address}'")]
+    PackageKindParseError { address: String, index: usize, raw: String, source: specifications::package::PackageKindError },
     /// Failed to parse the package's version in a package info.
-    VersionParseError { address: String, index: usize, raw: String, err: specifications::version::ParseError },
+    #[error("Failed to parse '{raw}' as version in package {index} returned by '{address}'")]
+    VersionParseError { address: String, index: usize, raw: String, source: specifications::version::ParseError },
     /// Failed to create a package index from the given infos.
-    PackageIndexError { address: String, err: specifications::package::PackageIndexError },
+    #[error("Failed to create a package index from the package infos given by '{address}'")]
+    PackageIndexError { address: String, source: specifications::package::PackageIndexError },
 
     /// Failed to create a data index from the given infos.
-    DataIndexError { address: String, err: specifications::data::DataIndexError },
+    #[error("Failed to create a data index from the data infos given by '{address}'")]
+    DataIndexError { address: String, source: specifications::data::DataIndexError },
 }
-impl Display for ApiError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ApiError::*;
-        match self {
-            RequestError { address, .. } => write!(f, "Failed to post request to '{address}'"),
-            ResponseBodyError { address, .. } => write!(f, "Failed to get body from response from '{address}'"),
-            ResponseJsonParseError { address, raw, .. } => write!(f, "Failed to parse response \"\"\"{raw}\"\"\" from '{address}' as JSON"),
-            NoResponse { address } => write!(f, "'{address}' responded without a body (not even that no packages are available)"),
-
-            PackageKindParseError { address, index, raw, .. } => {
-                write!(f, "Failed to parse '{raw}' as package kind in package {index} returned by '{address}'")
-            },
-            VersionParseError { address, index, raw, .. } => {
-                write!(f, "Failed to parse '{raw}' as version in package {index} returned by '{address}'")
-            },
-            PackageIndexError { address, .. } => write!(f, "Failed to create a package index from the package infos given by '{address}'"),
-
-            DataIndexError { address, .. } => write!(f, "Failed to create a data index from the data infos given by '{address}'"),
-        }
-    }
-}
-impl Error for ApiError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use ApiError::*;
-        match self {
-            RequestError { err, .. } => Some(err),
-            ResponseBodyError { err, .. } => Some(err),
-            ResponseJsonParseError { err, .. } => Some(err),
-            NoResponse { .. } => None,
-
-            PackageKindParseError { err, .. } => Some(err),
-            VersionParseError { err, .. } => Some(err),
-            PackageIndexError { err, .. } => Some(err),
-
-            DataIndexError { err, .. } => Some(err),
-        }
-    }
-}
-
-
 
 /// Errors that relate to parsing Docker client version numbers.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ClientVersionParseError {
     /// Missing a dot in the version number
+    #[error("Missing '.' in Docket client version number '{raw}'")]
     MissingDot { raw: String },
     /// The given major version was not a valid usize
-    IllegalMajorNumber { raw: String, err: std::num::ParseIntError },
+    #[error("'{raw}' is not a valid Docket client version major number")]
+    IllegalMajorNumber { raw: String, source: std::num::ParseIntError },
     /// The given major version was not a valid usize
-    IllegalMinorNumber { raw: String, err: std::num::ParseIntError },
-}
-impl Display for ClientVersionParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ClientVersionParseError::*;
-        match self {
-            MissingDot { raw } => write!(f, "Missing '.' in Docket client version number '{raw}'"),
-            IllegalMajorNumber { raw, .. } => write!(f, "'{raw}' is not a valid Docket client version major number"),
-            IllegalMinorNumber { raw, .. } => write!(f, "'{raw}' is not a valid Docket client version minor number"),
-        }
-    }
-}
-impl Error for ClientVersionParseError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use ClientVersionParseError::*;
-        match self {
-            MissingDot { .. } => None,
-            IllegalMajorNumber { err, .. } => Some(err),
-            IllegalMinorNumber { err, .. } => Some(err),
-        }
-    }
+    #[error("'{raw}' is not a valid Docket client version minor number")]
+    IllegalMinorNumber { raw: String, source: std::num::ParseIntError },
 }

--- a/brane-tsk/src/spec.rs
+++ b/brane-tsk/src/spec.rs
@@ -46,7 +46,7 @@ macro_rules! return_status_val {
         if let Some(s) = $str {
             match serde_json::from_str(&s) {
                 Ok(val) => Ok(JobStatus::$status(val)),
-                Err(err) => Err(ExecuteError::StatusValueParseError { status: TaskStatus::$status, raw: s, err }),
+                Err(source) => Err(ExecuteError::StatusValueParseError { status: TaskStatus::$status, raw: s, source }),
             }
         } else {
             Err(ExecuteError::StatusEmptyStringError { status: TaskStatus::$status })
@@ -60,7 +60,7 @@ macro_rules! return_status_failed {
         if let Some(s) = $str {
             match serde_json::from_str::<(i32, String, String)>(&s) {
                 Ok((code, stdout, stderr)) => Ok(JobStatus::$status(code, stdout, stderr)),
-                Err(err) => Err(ExecuteError::StatusTripletParseError { status: TaskStatus::$status, raw: s, err }),
+                Err(source) => Err(ExecuteError::StatusTripletParseError { status: TaskStatus::$status, raw: s, source }),
             }
         } else {
             Err(ExecuteError::StatusEmptyStringError { status: TaskStatus::$status })
@@ -118,7 +118,7 @@ impl FromStr for AppId {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match Uuid::from_str(value) {
             Ok(uuid) => Ok(Self(uuid)),
-            Err(err) => Err(IdError::ParseError { what: "AppId", raw: value.into(), err }),
+            Err(source) => Err(IdError::ParseError { what: "AppId", raw: value.into(), source }),
         }
     }
 }
@@ -165,7 +165,7 @@ impl FromStr for TaskId {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match Uuid::from_str(value) {
             Ok(uuid) => Ok(Self(uuid)),
-            Err(err) => Err(IdError::ParseError { what: "TaskId", raw: value.into(), err }),
+            Err(source) => Err(IdError::ParseError { what: "TaskId", raw: value.into(), source }),
         }
     }
 }

--- a/brane-tsk/src/tools.rs
+++ b/brane-tsk/src/tools.rs
@@ -32,18 +32,11 @@ pub fn decode_base64(raw: impl AsRef<str>) -> Result<String, ExecuteError> {
     let raw: &str = raw.as_ref();
 
     // First, try to decode the raw base64
-    let input: Vec<u8> = match base64::engine::general_purpose::STANDARD.decode(raw) {
-        Ok(bin) => bin,
-        Err(reason) => {
-            return Err(ExecuteError::Base64DecodeError { raw: raw.into(), err: reason });
-        },
-    };
+    let input: Vec<u8> =
+        base64::engine::general_purpose::STANDARD.decode(raw).map_err(|source| ExecuteError::Base64DecodeError { raw: raw.into(), source })?;
 
     // Next, try to decode the binary as UTF-8
-    match String::from_utf8(input.clone()) {
-        Ok(text) => Ok(text),
-        Err(reason) => Err(ExecuteError::Utf8DecodeError { raw: String::from_utf8_lossy(&input).into(), err: reason }),
-    }
+    String::from_utf8(input.clone()).map_err(|source| ExecuteError::Utf8DecodeError { raw: String::from_utf8_lossy(&input).into(), source })
 
     // We leave JSON for another day
 }

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -30,6 +30,7 @@ serde_with = "3.0.0"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
 strum = "0.27.0"
 strum_macros = "0.27.0"
+thiserror = "2.0.0"
 tonic = "0.12.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 

--- a/specifications/src/arch.rs
+++ b/specifications/src/arch.rs
@@ -12,7 +12,6 @@
  *   Defines enums and parsers to work with multiple architectures.
 **/
 
-use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FResult};
 use std::hash::Hash;
 use std::str::FromStr;
@@ -22,23 +21,12 @@ use serde::{Deserialize, Serialize};
 
 /***** ERRORS *****/
 /// Defines the error that may occur when parsing architectures
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ArchError {
     /// Could not deserialize the given string
+    #[error("Unknown architecture '{raw}'")]
     UnknownArchitecture { raw: String },
 }
-impl Display for ArchError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use ArchError::*;
-        match self {
-            UnknownArchitecture { raw } => write!(f, "Unknown architecture '{raw}'"),
-        }
-    }
-}
-impl Error for ArchError {}
-
-
-
 
 
 /***** AUXILLARY *****/

--- a/specifications/src/common.rs
+++ b/specifications/src/common.rs
@@ -205,14 +205,11 @@ impl From<()> for Value {
     fn from(_: ()) -> Self { Value::Unit }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("Value does not contain a {what}")]
 pub struct CastError {
     what: &'static str,
 }
-impl Display for CastError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { write!(f, "Value does not contain a {}", self.what) }
-}
-impl std::error::Error for CastError {}
 
 impl Value {
     pub fn from_json(value: &JValue) -> Self {

--- a/specifications/src/data.rs
+++ b/specifications/src/data.rs
@@ -14,7 +14,6 @@
 //
 
 use std::collections::HashMap;
-use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FResult};
 use std::fs::File;
 use std::io::{Read, Write};
@@ -27,124 +26,69 @@ use serde::{Deserialize, Serialize};
 
 /***** ERRORS *****/
 /// Defines (parsing) errors that relate to the [`DataIndex`] struct.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DataIndexError {
     /// Failed to open the given file.
-    FileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open data index file '{}'", path.display())]
+    FileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read/parse the given file.
-    FileParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse data index file '{}'", path.display())]
+    FileParseError { path: PathBuf, source: serde_yaml::Error },
 
     /// Failed to parse the given reader.
-    ReaderParseError { err: serde_yaml::Error },
+    #[error("Failed to parse given reader as a data index file")]
+    ReaderParseError { source: serde_yaml::Error },
     /// A given asset has appeared multiple times.
+    #[error("Location '{location}' defines an asset with identifier '{name}' more than once")]
     DuplicateAsset { location: String, name: String },
 }
 
-impl Display for DataIndexError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DataIndexError::*;
-        match self {
-            FileOpenError { path, err } => write!(f, "Failed to open data index file '{}': {}", path.display(), err),
-            FileParseError { path, err } => write!(f, "Failed to parse data index file '{}': {}", path.display(), err),
-
-            ReaderParseError { err } => write!(f, "Failed to parse given reader as a data index file: {err}"),
-            DuplicateAsset { location, name } => write!(f, "Location '{location}' defines an asset with identifier '{name}' more than once"),
-        }
-    }
-}
-
-impl Error for DataIndexError {}
-
-
-
 /// Defines errors that relate to the [`RuntimeDataIndex`] struct.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RuntimeDataIndexError {
     /// A dataset was already known under this name.
+    #[error("A dataset under the name of '{name}' was already defined")]
     DuplicateDataset { name: String },
 }
 
-impl Display for RuntimeDataIndexError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use RuntimeDataIndexError::*;
-        match self {
-            DuplicateDataset { name } => write!(f, "A dataset under the name of '{name}' was already defined"),
-        }
-    }
-}
-
-impl Error for RuntimeDataIndexError {}
-
-
-
 /// Defines (parsing) errors that relate to the [`DataInfo`] struct.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum DataInfoError {
     /// Failed to open the given file.
-    FileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open data info file '{}'", path.display())]
+    FileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read/parse the given file.
-    FileParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse data info file '{}'", path.display())]
+    FileParseError { path: PathBuf, source: serde_yaml::Error },
     /// Failed to create the given file.
-    FileCreateError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to create data info file '{}'", path.display())]
+    FileCreateError { path: PathBuf, source: std::io::Error },
     /// Failed to write to the given file.
-    FileWriteError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to write to data info file '{}'", path.display())]
+    FileWriteError { path: PathBuf, source: serde_yaml::Error },
 
     /// Failed to parse the given reader.
-    ReaderParseError { err: serde_yaml::Error },
+    #[error("Failed to parse given reader as a data info file")]
+    ReaderParseError { source: serde_yaml::Error },
     /// Failed to write to the given writer.
-    WriterWriteError { err: serde_yaml::Error },
+    #[error("Failed to write the data info file to given writer")]
+    WriterWriteError { source: serde_yaml::Error },
 }
-
-impl Display for DataInfoError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use DataInfoError::*;
-        match self {
-            FileOpenError { path, err } => write!(f, "Failed to open data info file '{}': {}", path.display(), err),
-            FileParseError { path, err } => write!(f, "Failed to parse data info file '{}': {}", path.display(), err),
-            FileCreateError { path, err } => write!(f, "Failed to create data info file '{}': {}", path.display(), err),
-            FileWriteError { path, err } => write!(f, "Failed to write to data info file '{}': {}", path.display(), err),
-
-            ReaderParseError { err } => write!(f, "Failed to parse given reader as a data info file: {err}"),
-            WriterWriteError { err } => write!(f, "Failed to write the data info file to given writer: {err}"),
-        }
-    }
-}
-
-impl Error for DataInfoError {}
 
 /// Defines (parsing) errors that relate to the [`AssetInfo`] struct.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum AssetInfoError {
     /// Failed to open the given file.
-    FileOpenError { path: PathBuf, err: std::io::Error },
+    #[error("Failed to open asset info file '{}'", path.display())]
+    FileOpenError { path: PathBuf, source: std::io::Error },
     /// Failed to read/parse the given file.
-    FileParseError { path: PathBuf, err: serde_yaml::Error },
+    #[error("Failed to parse asset info file '{}'", path.display())]
+    FileParseError { path: PathBuf, source: serde_yaml::Error },
 
     /// Failed to parse the given reader.
-    ReaderParseError { err: serde_yaml::Error },
+    #[error("Failed to parse given reader as a asset info file")]
+    ReaderParseError { source: serde_yaml::Error },
 }
-
-impl Display for AssetInfoError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-        use AssetInfoError::*;
-        match self {
-            FileOpenError { path, err } => write!(f, "Failed to open asset info file '{}': {}", path.display(), err),
-            FileParseError { path, err } => write!(f, "Failed to parse asset info file '{}': {}", path.display(), err),
-
-            ReaderParseError { err } => write!(f, "Failed to parse given reader as a asset info file: {err}"),
-        }
-    }
-}
-
-impl Error for AssetInfoError {}
-
-
-
-
 
 // /***** HELPER STRUCTS *****/
 // /// Defines a more general DataInfo used in the DataIndex.
@@ -358,18 +302,12 @@ impl DataIndex {
         let path: &Path = path.as_ref();
 
         // Open the file
-        let handle: File = match File::open(path) {
-            Ok(handle) => handle,
-            Err(err) => {
-                return Err(DataIndexError::FileOpenError { path: path.into(), err });
-            },
-        };
+        let handle: File = File::open(path).map_err(|source| DataIndexError::FileOpenError { path: path.into(), source })?;
 
         // Pass to the reader for the heavy lifting
         match Self::from_reader(handle) {
-            Ok(res) => Ok(res),
-            Err(DataIndexError::ReaderParseError { err }) => Err(DataIndexError::FileParseError { path: path.into(), err }),
-            Err(err) => Err(err),
+            Err(DataIndexError::ReaderParseError { source }) => Err(DataIndexError::FileParseError { path: path.into(), source }),
+            x => x,
         }
     }
 
@@ -388,10 +326,7 @@ impl DataIndex {
     /// This function errors if we could not read or parse the reader.
     #[inline]
     pub fn from_reader<R: Read>(reader: R) -> Result<Self, DataIndexError> {
-        match serde_yaml::from_reader(reader) {
-            Ok(res) => Ok(res),
-            Err(err) => Err(DataIndexError::ReaderParseError { err }),
-        }
+        serde_yaml::from_reader(reader).map_err(|source| DataIndexError::ReaderParseError { source })
     }
 
     /// Constructor for the `DataIndex` that creates it from a list of [`DataInfo`]s.
@@ -606,18 +541,12 @@ impl DataInfo {
         let path: &Path = path.as_ref();
 
         // Open the file
-        let handle: File = match File::open(path) {
-            Ok(handle) => handle,
-            Err(err) => {
-                return Err(DataInfoError::FileOpenError { path: path.into(), err });
-            },
-        };
+        let handle: File = File::open(path).map_err(|source| DataInfoError::FileOpenError { path: path.into(), source })?;
 
         // Pass to the reader for the heavy lifting
         match Self::from_reader(handle) {
-            Ok(res) => Ok(res),
-            Err(DataInfoError::ReaderParseError { err }) => Err(DataInfoError::FileParseError { path: path.into(), err }),
-            Err(err) => Err(err),
+            Err(DataInfoError::ReaderParseError { source }) => Err(DataInfoError::FileParseError { path: path.into(), source }),
+            x => x,
         }
     }
 
@@ -636,10 +565,7 @@ impl DataInfo {
     /// This function errors if we could not read or parse the reader.
     #[inline]
     pub fn from_reader<R: Read>(reader: R) -> Result<Self, DataInfoError> {
-        match serde_yaml::from_reader(reader) {
-            Ok(res) => Ok(res),
-            Err(err) => Err(DataInfoError::ReaderParseError { err }),
-        }
+        serde_yaml::from_reader(reader).map_err(|source| DataInfoError::ReaderParseError { source })
     }
 
     /// Writes the `DataInfo` to the given path.
@@ -654,18 +580,12 @@ impl DataInfo {
     /// This function errors if we could not create or write to the new file.
     pub fn to_path(&self, path: impl AsRef<Path>) -> Result<(), DataInfoError> {
         // Open the file
-        let handle: File = match File::create(path.as_ref()) {
-            Ok(handle) => handle,
-            Err(err) => {
-                return Err(DataInfoError::FileCreateError { path: path.as_ref().into(), err });
-            },
-        };
+        let handle: File = File::create(path.as_ref()).map_err(|source| DataInfoError::FileCreateError { path: path.as_ref().into(), source })?;
 
         // Do the rest by virtue of `DataInfo::to_writer()`
         match self.to_writer(handle) {
-            Ok(_) => Ok(()),
-            Err(DataInfoError::WriterWriteError { err }) => Err(DataInfoError::FileWriteError { path: path.as_ref().into(), err }),
-            Err(err) => Err(err),
+            Err(DataInfoError::WriterWriteError { source }) => Err(DataInfoError::FileWriteError { path: path.as_ref().into(), source }),
+            x => x,
         }
     }
 
@@ -681,10 +601,7 @@ impl DataInfo {
     /// This function errors if we could not write to the given writer.
     #[inline]
     pub fn to_writer(&self, writer: impl Write) -> Result<(), DataInfoError> {
-        match serde_yaml::to_writer(writer, self) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(DataInfoError::WriterWriteError { err }),
-        }
+        serde_yaml::to_writer(writer, self).map_err(|source| DataInfoError::WriterWriteError { source })
     }
 }
 
@@ -722,18 +639,12 @@ impl AssetInfo {
         let path: &Path = path.as_ref();
 
         // Open the file
-        let handle: File = match File::open(path) {
-            Ok(handle) => handle,
-            Err(err) => {
-                return Err(AssetInfoError::FileOpenError { path: path.into(), err });
-            },
-        };
+        let handle: File = File::open(path).map_err(|source| AssetInfoError::FileOpenError { path: path.into(), source })?;
 
         // Pass to the reader for the heavy lifting
         match Self::from_reader(handle) {
-            Ok(res) => Ok(res),
-            Err(AssetInfoError::ReaderParseError { err }) => Err(AssetInfoError::FileParseError { path: path.into(), err }),
-            Err(err) => Err(err),
+            Err(AssetInfoError::ReaderParseError { source }) => Err(AssetInfoError::FileParseError { path: path.into(), source }),
+            x => x,
         }
     }
 
@@ -752,10 +663,7 @@ impl AssetInfo {
     /// This function errors if we could not read or parse the reader.
     #[inline]
     pub fn from_reader<R: Read>(reader: R) -> Result<Self, AssetInfoError> {
-        match serde_yaml::from_reader::<R, Self>(reader) {
-            Ok(res) => Ok(res),
-            Err(err) => Err(AssetInfoError::ReaderParseError { err }),
-        }
+        serde_yaml::from_reader::<R, Self>(reader).map_err(|source| AssetInfoError::ReaderParseError { source })
     }
 
     /// Converts this `AssetInfo` into a [`DataInfo`] under the given domain.

--- a/specifications/src/errors.rs
+++ b/specifications/src/errors.rs
@@ -18,62 +18,35 @@ use std::path::PathBuf;
 
 /***** ERROR ENUMS *****/
 /// Errors that relate to finding Brane directories
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum SystemDirectoryError {
     /// Could not find the user local data folder
+    #[error("Could not find the user's local data directory for your OS (reported as {})", std::env::consts::OS)]
     UserLocalDataDirNotFound,
     /// Could not find the user config folder
+    #[error("Could not find the user's config directory for your OS (reported as {})", std::env::consts::OS)]
     UserConfigDirNotFound,
 
     /// Could not find brane's folder in the data folder
+    #[error("Brane data directory '{}' not found", path.display())]
     BraneLocalDataDirNotFound { path: PathBuf },
     /// Could not find brane's folder in the config folder
+    #[error("Brane config directory '{}' not found", path.display())]
     BraneConfigDirNotFound { path: PathBuf },
 }
 
-impl std::fmt::Display for SystemDirectoryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SystemDirectoryError::UserLocalDataDirNotFound => {
-                write!(f, "Could not find the user's local data directory for your OS (reported as {})", std::env::consts::OS)
-            },
-            SystemDirectoryError::UserConfigDirNotFound => {
-                write!(f, "Could not find the user's config directory for your OS (reported as {})", std::env::consts::OS)
-            },
-
-            SystemDirectoryError::BraneLocalDataDirNotFound { path } => write!(f, "Brane data directory '{}' not found", path.display()),
-            SystemDirectoryError::BraneConfigDirNotFound { path } => write!(f, "Brane config directory '{}' not found", path.display()),
-        }
-    }
-}
-
-impl std::error::Error for SystemDirectoryError {}
-
-
-
 /// Errors that relate to encoding or decoding output
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EncodeDecodeError {
     /// Could not decode the given string from Base64 binary data
-    Base64DecodeError { err: base64::DecodeError },
+    #[error("Could not decode string input as Base64")]
+    Base64DecodeError { source: base64::DecodeError },
 
     /// Could not decode the given raw binary using UTF-8
-    Utf8DecodeError { err: std::string::FromUtf8Error },
+    #[error("Could not decode binary input as UTF-8")]
+    Utf8DecodeError { source: std::string::FromUtf8Error },
 
     /// Could not decode the given input as JSON
-    JsonDecodeError { err: serde_json::Error },
+    #[error("Could not decode string input as JSON")]
+    JsonDecodeError { source: serde_json::Error },
 }
-
-impl std::fmt::Display for EncodeDecodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EncodeDecodeError::Base64DecodeError { err } => write!(f, "Could not decode string input as Base64: {err}"),
-
-            EncodeDecodeError::Utf8DecodeError { err } => write!(f, "Could not decode binary input as UTF-8: {err}"),
-
-            EncodeDecodeError::JsonDecodeError { err } => write!(f, "Could not decode string input as JSON: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for EncodeDecodeError {}


### PR DESCRIPTION
This PR refactors almost all our errors to use thiserror.

A couple of noteworthy points:

The attribute in a Error struct that defines what will be returned by `.source()` is called `source` now instead of `err`. Thiserror automatically recognizes it as a source in that case.

This also replaces a lot of excessive pattern matching with `.map_err` calls. I only did this for cases where the lines would be touched anyways by renaming `err` to `source` and where the `Ok()` side of the `Result` was untouched or an unwrap.

It compiles just fine, so that is good, but the chances of me making a mistake here are quite large, so I expect some regressions. On the other hand, I also expect a lot of source bugs to be fixed just because thiserror now does the `source` mapping automatically.

So henceforth please use `source` when wrapping an error inside another. Note that sometimes we still use err, but that should only be the case when the inner type does not implement `std::error::Error` as it cannot be a source in that case.
