### PR TITLE
refactor: Restructure all cli interfaces

### DIFF
--- a/brane-api/src/cli.rs
+++ b/brane-api/src/cli.rs
@@ -1,0 +1,23 @@
+//! This module contains all logic and structures with respect to argument handling and invocation of this command
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+pub(crate) struct Cli {
+    /// Print debug info
+    #[clap(short, long, env = "DEBUG")]
+    pub(crate) debug: bool,
+
+    /// Load everything from the node.yml file
+    #[clap(
+        short,
+        long,
+        default_value = "/node.yml",
+        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
+                files, as wel as this service's service address.",
+        env = "NODE_CONFIG_PATH"
+    )]
+    pub(crate) node_config_path: PathBuf,
+}

--- a/brane-api/src/main.rs
+++ b/brane-api/src/main.rs
@@ -12,6 +12,8 @@
 //!   Entrypoint to the `brane-job` service.
 //
 
+mod cli;
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,35 +35,12 @@ use tokio::signal::unix::{Signal, SignalKind, signal};
 use warp::Filter;
 
 
-/***** ARGUMENTS *****/
-#[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"))]
-struct Opts {
-    /// Print debug info
-    #[clap(short, long, env = "DEBUG")]
-    debug: bool,
-
-    /// Load everything from the node.yml file
-    #[clap(
-        short,
-        long,
-        default_value = "/node.yml",
-        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
-                files, as wel as this service's service address.",
-        env = "NODE_CONFIG_PATH"
-    )]
-    node_config_path: PathBuf,
-}
-
-
-
-
 
 /***** ENTRYPOINT *****/
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let opts = Opts::parse();
+    let opts = cli::Cli::parse();
 
     // Configure logger.
     let mut logger = env_logger::builder();

--- a/brane-cc/src/cli.rs
+++ b/brane-cc/src/cli.rs
@@ -1,0 +1,77 @@
+use brane_cc::spec::IndexLocation;
+use brane_dsl::Language;
+use clap::Parser;
+
+/// The arguments for the `branec` binary.
+#[derive(Parser)]
+#[clap(name = "branec", author, about = "An offline compiler for BraneScript/Bakery to Workflows.")]
+pub(crate) struct Cli {
+    /// If given, shows debug prints.
+    #[clap(long, help = "If given, shows INFO- and DEBUG-level prints in the log.", env = "DEBUG")]
+    pub(crate) debug: bool,
+    /// If given, shows additional trace prints.
+    #[clap(long, help = "If given, shows TRACE-level prints in the log. Implies '--debug'", env = "TRACE")]
+    pub(crate) trace: bool,
+
+    /// The file(s) to compile. May be '-' to compile from stdin.
+    #[clap(name = "FILES", help = "The input files to compile. Use '-' to read from stdin.")]
+    pub(crate) files:    Vec<String>,
+    /// The output file to write to.
+    #[clap(short, long, default_value = "-", help = "The output file to compile to. Use '-' to write to stdout.")]
+    pub(crate) output:   String,
+    /// The path / address of the packages index.
+    #[clap(
+        short,
+        long,
+        default_value = "~/.local/share/brane/packages",
+        help = "The location to read the package index from. If it's a path, reads it from the local machine; if it's an address, attempts to read \
+                it from the Brane instance instead. You can wrap your input in 'Local<...>' or 'Remote<...>' to disambiguate between the two."
+    )]
+    pub(crate) packages: IndexLocation,
+    /// The path / address of the data index.
+    #[clap(
+        short,
+        long,
+        default_value = "~/.local/share/brane/data",
+        help = "The location to read the data index from. If it's a path, reads it from the local machine; if it's an address, attempts to read it \
+                from the Brane instance instead. You can wrap your input in 'Local<...>' or 'Remote<...>' to disambiguate between the two."
+    )]
+    pub(crate) data:     IndexLocation,
+    /// If given, reads the packages and data in test mode, which simplifies how to interpret them since we won't be executing them.
+    #[clap(
+        short,
+        long,
+        help = "If given, reads packages and data simplified as found in the `tests` folder in the Brane repository. This can be done because the \
+                packages won't be executed."
+    )]
+    pub(crate) raw:      bool,
+
+    /// If given, does the stream thing
+    #[clap(
+        short,
+        long,
+        help = "If given, enters so-called _streaming mode_. This effectively emulates a REPL, where files may be given on stdin indefinitely \
+                (separated by EOF, Ctrl+D). Each file is compiled as soon as it is completely received, and the workflow for that file is written \
+                to the output file. Workflows can use definitions made in pervious workflows, just like a REPL."
+    )]
+    pub(crate) stream:   bool,
+    /// Determines the input language of the source.
+    #[clap(short, long, default_value = "bscript", help = "Determines the language of the input files.")]
+    pub(crate) language: Language,
+    /// If given, writes the output JSON to use as little whitespace as possible.
+    #[clap(
+        short,
+        long,
+        help = "If given, writes the output JSON in minimized format (i.e., with as little whitespace as possible). Not really readable, but \
+                perfect for transmitting it to some other program."
+    )]
+    pub(crate) compact:  bool,
+    /// If given, does not output JSON but instead outputs an assembly-like variant of a workflow.
+    #[clap(
+        short = 'P',
+        long,
+        help = "If given, does not output JSON but instead outputs an assembly-like variant of a workflow. Not really readable by machines, but \
+                easier to understand by a human (giving this ignores --compact)."
+    )]
+    pub(crate) pretty:   bool,
+}

--- a/brane-cli/src/main.rs
+++ b/brane-cli/src/main.rs
@@ -12,6 +12,8 @@
 //!   Entrypoint to the CLI binary.
 //
 
+mod cli;
+
 #[macro_use]
 extern crate human_panic;
 
@@ -26,6 +28,7 @@ use brane_dsl::Language;
 use brane_shr::fs::DownloadSecurity;
 use brane_tsk::docker::DockerOptions;
 use clap::Parser;
+use cli::*;
 use dotenvy::dotenv;
 use error_trace::ErrorTrace as _;
 use humanlog::{DebugMode, HumanLogger};
@@ -37,15 +40,13 @@ use specifications::version::Version as SemVersion;
 use tempfile::TempDir;
 
 
-mod cli;
-use cli::*;
 
 /***** ENTRYPOINT *****/
 #[tokio::main]
 async fn main() -> Result<()> {
     // Parse the CLI arguments
     dotenv().ok();
-    let options = Cli::parse();
+    let options = cli::Cli::parse();
 
     // Prepare the logger
     if let Err(err) = HumanLogger::terminal(if options.debug { DebugMode::Debug } else { DebugMode::HumanFriendly }).init() {

--- a/brane-ctl/src/cli.rs
+++ b/brane-ctl/src/cli.rs
@@ -15,13 +15,11 @@ use specifications::arch::Arch;
 use specifications::package::Capability;
 use specifications::version::Version;
 
-pub(crate) fn parse() -> Arguments { Arguments::parse() }
-
 /***** ARGUMENTS *****/
 /// Defines the toplevel arguments for the `branectl` tool.
 #[derive(Debug, Parser)]
 #[clap(name = "branectl", about = "The server-side Brane command-line interface.")]
-pub(crate) struct Arguments {
+pub(crate) struct Cli {
     /// If given, prints `info` and `debug` prints.
     #[clap(long, global = true, help = "If given, prints additional information during execution.")]
     pub(crate) debug: bool,

--- a/brane-ctl/src/completions.rs
+++ b/brane-ctl/src/completions.rs
@@ -9,7 +9,7 @@ mod cli;
 use cli::*;
 
 fn main() {
-    let mut command = Arguments::command();
+    let mut command = Cli::command();
 
     for (filename, shell) in [("branectl.bash", Bash), ("branectl.fish", Fish), ("branectl.zsh", Zsh)] {
         let mut file = File::create(filename).expect("Could not open/create completions file");

--- a/brane-ctl/src/main.rs
+++ b/brane-ctl/src/main.rs
@@ -12,18 +12,20 @@
 //!   Entrypoint to the `branectl` executable.
 //
 
+pub mod cli;
 
 use brane_cfg::proxy::ForwardConfig;
 use brane_ctl::spec::{LogsOpts, StartOpts};
 use brane_ctl::{download, generate, lifetime, packages, policies, unpack, upgrade, wizard};
 use brane_tsk::docker::DockerOptions;
+use clap::Parser;
+use cli::*;
 use dotenvy::dotenv;
 use error_trace::ErrorTrace as _;
 use humanlog::{DebugMode, HumanLogger};
 use log::error;
 
-pub mod cli;
-use cli::*;
+
 
 /***** ENTYRPOINT *****/
 #[tokio::main(flavor = "current_thread")]
@@ -32,7 +34,7 @@ async fn main() {
     dotenv().ok();
 
     // Parse the arguments
-    let args = cli::parse();
+    let args = cli::Cli::parse();
 
     // Initialize the logger
     if let Err(err) = HumanLogger::terminal(if args.trace {

--- a/brane-drv/src/cli.rs
+++ b/brane-drv/src/cli.rs
@@ -1,0 +1,27 @@
+/***** ARGUMENTS *****/
+use std::path::PathBuf;
+
+use clap::Parser;
+
+/// Defines the arguments that may be given to the service.
+#[derive(Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+pub(crate) struct Cli {
+    /// Print debug info
+    #[clap(short, long, action, help = "If given, prints additional logging information.", env = "DEBUG")]
+    pub(crate) debug:    bool,
+    /// Consumer group id
+    #[clap(short, long, default_value = "brane-drv", help = "The group ID of this service's consumer")]
+    pub(crate) group_id: String,
+
+    /// Node environment metadata store.
+    #[clap(
+        short,
+        long,
+        default_value = "/node.yml",
+        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
+                files, as wel as this service's service address.",
+        env = "NODE_CONFIG_PATH"
+    )]
+    pub(crate) node_config_path: PathBuf,
+}

--- a/brane-drv/src/main.rs
+++ b/brane-drv/src/main.rs
@@ -12,7 +12,8 @@
 //!   Entrypoint to the `brane-drv` service.
 //
 
-use std::path::PathBuf;
+mod cli;
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,39 +30,12 @@ use tokio::signal::unix::{Signal, SignalKind, signal};
 use tonic::transport::Server;
 
 
-/***** ARGUMENTS *****/
-/// Defines the arguments that may be given to the service.
-#[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"))]
-struct Opts {
-    /// Print debug info
-    #[clap(short, long, action, help = "If given, prints additional logging information.", env = "DEBUG")]
-    debug:    bool,
-    /// Consumer group id
-    #[clap(short, long, default_value = "brane-drv", help = "The group ID of this service's consumer")]
-    group_id: String,
-
-    /// Node environment metadata store.
-    #[clap(
-        short,
-        long,
-        default_value = "/node.yml",
-        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
-                files, as wel as this service's service address.",
-        env = "NODE_CONFIG_PATH"
-    )]
-    node_config_path: PathBuf,
-}
-
-
-
-
 
 /***** ENTRY POINT *****/
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let opts = Opts::parse();
+    let opts = cli::Cli::parse();
 
     // Configure logger.
     let mut logger = env_logger::builder();

--- a/brane-job/src/cli.rs
+++ b/brane-job/src/cli.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+pub(crate) struct Cli {
+    /// Print debug info
+    #[clap(long, action, help = "If given, shows additional logging information.", env = "DEBUG")]
+    pub(crate) debug: bool,
+    /// Whether to keep containers after execution or not.
+    #[clap(long, action, help = "If given, will not remove job containers after removing them.", env = "KEEP_CONTAINERS")]
+    pub(crate) keep_containers: bool,
+
+    /// Node environment metadata store.
+    #[clap(
+        short,
+        long,
+        default_value = "/node.yml",
+        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
+                files, as wel as this service's service address.",
+        env = "NODE_CONFIG_PATH"
+    )]
+    pub(crate) node_config_path: PathBuf,
+}

--- a/brane-job/src/main.rs
+++ b/brane-job/src/main.rs
@@ -12,7 +12,6 @@
 //!   Entrypoint to the `brane-job` service.
 //
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -28,39 +27,13 @@ use specifications::working::JobServiceServer;
 use tokio::signal::unix::{Signal, SignalKind, signal};
 use tonic::transport::Server;
 
-
-/***** ARGUMENTS *****/
-#[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"))]
-struct Opts {
-    /// Print debug info
-    #[clap(long, action, help = "If given, shows additional logging information.", env = "DEBUG")]
-    debug: bool,
-    /// Whether to keep containers after execution or not.
-    #[clap(long, action, help = "If given, will not remove job containers after removing them.", env = "KEEP_CONTAINERS")]
-    keep_containers: bool,
-
-    /// Node environment metadata store.
-    #[clap(
-        short,
-        long,
-        default_value = "/node.yml",
-        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
-                files, as wel as this service's service address.",
-        env = "NODE_CONFIG_PATH"
-    )]
-    node_config_path: PathBuf,
-}
-
-
-
-
+mod cli;
 
 /***** ENTRYPOINT *****/
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let opts = Opts::parse();
+    let opts = cli::Cli::parse();
 
     // Configure logger.
     let mut logger = env_logger::builder();

--- a/brane-let/src/cli.rs
+++ b/brane-let/src/cli.rs
@@ -1,0 +1,43 @@
+/***** ARGUMENTS *****/
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+pub(crate) struct Cli {
+    #[clap(short, long, env = "BRANE_APPLICATION_ID")]
+    pub(crate) application_id: String,
+    #[clap(short, long, env = "BRANE_LOCATION_ID")]
+    pub(crate) location_id: String,
+    #[clap(short, long, env = "BRANE_JOB_ID")]
+    pub(crate) job_id: String,
+    #[clap(short, long, env = "BRANE_CALLBACK_TO")]
+    pub(crate) callback_to: Option<String>,
+    #[clap(short, long, env = "BRANE_PROXY_ADDRESS")]
+    pub(crate) proxy_address: Option<String>,
+    #[clap(short, long, env = "BRANE_MOUNT_DFS")]
+    pub(crate) mount_dfs: Option<String>,
+    /// Prints debug info
+    #[clap(short, long, action, env = "DEBUG")]
+    pub(crate) debug: bool,
+    #[clap(subcommand)]
+    pub(crate) sub_command: SubCommand,
+}
+
+#[derive(Parser, Clone)]
+pub(crate) enum SubCommand {
+    /// Execute arbitrary source code and return output
+    #[clap(name = "ecu")]
+    Code {
+        /// Function to execute
+        function:    String,
+        /// Input arguments (encoded, as Base64'ed JSON)
+        arguments:   String,
+        #[clap(short, long, env = "BRANE_WORKDIR", default_value = "/opt/wd")]
+        working_dir: PathBuf,
+    },
+    /// Don't perform any operation and return nothing
+    #[clap(name = "no-op")]
+    NoOp,
+}

--- a/brane-let/src/main.rs
+++ b/brane-let/src/main.rs
@@ -13,7 +13,8 @@
 //!   things around there.
 //
 
-use std::path::PathBuf;
+mod cli;
+
 use std::process;
 
 use base64::Engine;
@@ -22,9 +23,11 @@ use brane_let::common::PackageResult;
 use brane_let::errors::LetError;
 use brane_let::{exec_ecu, exec_nop};
 use clap::Parser;
+use cli::*;
 use dotenvy::dotenv;
 use log::{LevelFilter, debug, warn};
 use serde::de::DeserializeOwned;
+
 
 
 /***** CONSTANTS *****/
@@ -35,58 +38,12 @@ const OUTPUT_PREFIX: &str = "[OUTPUT] ";
 
 
 
-
-
-/***** ARGUMENTS *****/
-#[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"))]
-struct Opts {
-    #[clap(short, long, env = "BRANE_APPLICATION_ID")]
-    application_id: String,
-    #[clap(short, long, env = "BRANE_LOCATION_ID")]
-    location_id: String,
-    #[clap(short, long, env = "BRANE_JOB_ID")]
-    job_id: String,
-    #[clap(short, long, env = "BRANE_CALLBACK_TO")]
-    callback_to: Option<String>,
-    #[clap(short, long, env = "BRANE_PROXY_ADDRESS")]
-    proxy_address: Option<String>,
-    #[clap(short, long, env = "BRANE_MOUNT_DFS")]
-    mount_dfs: Option<String>,
-    /// Prints debug info
-    #[clap(short, long, action, env = "DEBUG")]
-    debug: bool,
-    #[clap(subcommand)]
-    sub_command: SubCommand,
-}
-
-#[derive(Parser, Clone)]
-enum SubCommand {
-    /// Execute arbitrary source code and return output
-    #[clap(name = "ecu")]
-    Code {
-        /// Function to execute
-        function:    String,
-        /// Input arguments (encoded, as Base64'ed JSON)
-        arguments:   String,
-        #[clap(short, long, env = "BRANE_WORKDIR", default_value = "/opt/wd")]
-        working_dir: PathBuf,
-    },
-    /// Don't perform any operation and return nothing
-    #[clap(name = "no-op")]
-    NoOp,
-}
-
-
-
-
-
 /***** ENTRYPOINT *****/
 #[tokio::main]
 async fn main() {
     // Parse the arguments
     dotenv().ok();
-    let Opts { proxy_address, debug, sub_command, .. } = Opts::parse();
+    let cli::Cli { proxy_address, debug, sub_command, .. } = cli::Cli::parse();
 
     // Configure logger.
     let mut logger = env_logger::builder();

--- a/brane-plr/src/cli.rs
+++ b/brane-plr/src/cli.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
+pub(crate) struct Cli {
+    /// Print debug info
+    #[clap(short, long, action, help = "If given, prints additional logging information.", env = "TRACE")]
+    pub(crate) trace: bool,
+
+    /// Node environment metadata store.
+    #[clap(
+        short,
+        long,
+        default_value = "/node.yml",
+        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
+                files, as wel as this service's service address.",
+        env = "NODE_CONFIG_PATH"
+    )]
+    pub(crate) node_config_path: PathBuf,
+}

--- a/brane-plr/src/main.rs
+++ b/brane-plr/src/main.rs
@@ -12,22 +12,9 @@
 //!   Entrypoint to the `brane-plr` service.
 //
 
-//  MAIN.rs
-//    by Lut99
-//
-//  Created:
-//    30 Sep 2022, 16:10:59
-//  Last edited:
-//    17 Oct 2022, 17:27:08
-//  Auto updated?
-//    Yes
-//
-//  Description:
-//!   Entrypoint to the `brane-plr` service.
-//
+mod cli;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -46,36 +33,13 @@ use tokio::signal::unix::{Signal, SignalKind, signal};
 use warp::Filter as _;
 
 
-/***** ARGUMENTS *****/
-#[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"))]
-struct Opts {
-    /// Print debug info
-    #[clap(short, long, action, help = "If given, prints additional logging information.", env = "TRACE")]
-    trace: bool,
-
-    /// Node environment metadata store.
-    #[clap(
-        short,
-        long,
-        default_value = "/node.yml",
-        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
-                files, as wel as this service's service address.",
-        env = "NODE_CONFIG_PATH"
-    )]
-    node_config_path: PathBuf,
-}
-
-
-
-
 
 /***** ENTRYPOINT *****/
 #[tokio::main]
 async fn main() {
     // Load arguments & environment stuff
     dotenv().ok();
-    let opts = Opts::parse();
+    let opts = cli::Cli::parse();
 
     // Configure the logger.
     if let Err(err) = HumanLogger::terminal(if opts.trace { DebugMode::Full } else { DebugMode::Debug }).init() {

--- a/brane-prx/src/cli.rs
+++ b/brane-prx/src/cli.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[clap(name = "Brane proxy service", version = env!("CARGO_PKG_VERSION"), author, about = "A rudimentary, SOCKS-as-a-Service proxy service for outgoing connections from a domain.")]
+pub(crate) struct Cli {
+    /// Print debug info
+    #[clap(long, action, help = "If given, shows additional logging information.", env = "DEBUG")]
+    pub(crate) debug: bool,
+
+    /// Node environment metadata store.
+    #[clap(
+        short,
+        long,
+        default_value = "/node.yml",
+        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
+                files, as wel as this service's service address.",
+        env = "NODE_CONFIG_PATH"
+    )]
+    pub(crate) node_config_path: PathBuf,
+}

--- a/brane-prx/src/main.rs
+++ b/brane-prx/src/main.rs
@@ -12,9 +12,11 @@
 //!   Entrypoint to the `brane-prx` service.
 //
 
+mod cli;
+
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -32,35 +34,12 @@ use tokio::signal::unix::{Signal, SignalKind, signal};
 use warp::Filter;
 
 
-/***** ARGUMENTS *****/
-#[derive(Parser)]
-#[clap(name = "Brane proxy service", version = env!("CARGO_PKG_VERSION"), author, about = "A rudimentary, SOCKS-as-a-Service proxy service for outgoing connections from a domain.")]
-struct Arguments {
-    /// Print debug info
-    #[clap(long, action, help = "If given, shows additional logging information.", env = "DEBUG")]
-    debug: bool,
-
-    /// Node environment metadata store.
-    #[clap(
-        short,
-        long,
-        default_value = "/node.yml",
-        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
-                files, as wel as this service's service address.",
-        env = "NODE_CONFIG_PATH"
-    )]
-    node_config_path: PathBuf,
-}
-
-
-
-
 
 /***** ENTRYPOINT *****/
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let args: Arguments = Arguments::parse();
+    let args = cli::Cli::parse();
 
     // Configure logger.
     let mut logger = env_logger::builder();

--- a/brane-reg/src/cli.rs
+++ b/brane-reg/src/cli.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+/// Defines the arguments for the `brane-reg` service.
+#[derive(Parser)]
+pub(crate) struct Cli {
+    #[clap(long, action, help = "If given, provides additional debug prints on the logger.", env = "DEBUG")]
+    pub(crate) debug: bool,
+
+    /// Load everything from the node.yml file
+    #[clap(
+        short,
+        long,
+        default_value = "/node.yml",
+        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
+                files, as wel as this service's service address.",
+        env = "NODE_CONFIG_PATH"
+    )]
+    pub(crate) node_config_path: PathBuf,
+}

--- a/brane-reg/src/main.rs
+++ b/brane-reg/src/main.rs
@@ -12,7 +12,8 @@
 //!   Entrypoint to the `brane-reg` service.
 //
 
-use std::path::PathBuf;
+mod cli;
+
 use std::sync::Arc;
 
 use brane_cfg::info::Info as _;
@@ -28,35 +29,13 @@ use rustls::Certificate;
 use warp::Filter;
 
 
-/***** ARGUMENTS *****/
-/// Defines the arguments for the `brane-reg` service.
-#[derive(Parser)]
-struct Args {
-    #[clap(long, action, help = "If given, provides additional debug prints on the logger.", env = "DEBUG")]
-    debug: bool,
-
-    /// Load everything from the node.yml file
-    #[clap(
-        short,
-        long,
-        default_value = "/node.yml",
-        help = "The path to the node environment configuration. This defines things such as where local services may be found or where to store \
-                files, as wel as this service's service address.",
-        env = "NODE_CONFIG_PATH"
-    )]
-    node_config_path: PathBuf,
-}
-
-
-
-
 
 /***** ENTYRPOINT *****/
 #[tokio::main]
 async fn main() {
     // Read the env & CLI args
     dotenv().ok();
-    let args = Args::parse();
+    let args = cli::Cli::parse();
 
     // Setup the logger according to the debug flag
     let mut logger = env_logger::builder();


### PR DESCRIPTION
All command line arguments are now defined in a separate module called
cli and the main parser is called `Cli`. This helps a lot with external
imports of these modules, i.e. xtasks in our case.
