### PR TITLE
fix(cli-c): Use c_char for c chars instead of platform specific i8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,23 @@ jobs:
       packages: workspace
       cache: true
 
+  check-stable-linux-arm:
+    name: "Check"
+    uses: ./.github/workflows/mixin-cargo-check.yml
+    with:
+      os: ubuntu-24.04-arm
+      packages: frontend
+      cache: true
+
+  build-stable-linux-arm:
+    needs: check-stable-linux-arm
+    name: "Build"
+    uses: ./.github/workflows/mixin-cargo-build.yml
+    with:
+      os: ubuntu-24.04-arm
+      packages: frontend
+      cache: true
+
   check-stable-windows:
     name: "Check"
     uses: ./.github/workflows/mixin-cargo-check.yml

--- a/brane-cli-c/src/lib.rs
+++ b/brane-cli-c/src/lib.rs
@@ -150,7 +150,7 @@ unsafe fn rust_to_cstr(string: String) -> *mut c_char {
     let n_chars: usize = string.as_bytes().len();
     let target: *mut c_char = libc::malloc(n_chars + 1) as *mut c_char;
     libc::strncpy(target, string.as_ptr(), n_chars);
-    std::slice::from_raw_parts_mut(target, n_chars + 1)[n_chars] = '\0' as i8;
+    std::slice::from_raw_parts_mut(target, n_chars + 1)[n_chars] = '\0' as core::ffi::c_char;
 
     // Return the string
     target
@@ -486,7 +486,7 @@ pub unsafe extern "C" fn serror_serialize_swarns(serr: *const SourceError, buffe
     if serr.warns.is_empty() {
         // Write a single-byte buffer with only the null buffer
         let target: *mut c_char = libc::malloc(1) as *mut c_char;
-        std::slice::from_raw_parts_mut(target, 1)[0] = '\0' as i8;
+        std::slice::from_raw_parts_mut(target, 1)[0] = '\0' as core::ffi::c_char;
         *buffer = target;
 
         // A'ight that's it then
@@ -535,7 +535,7 @@ pub unsafe extern "C" fn serror_serialize_serrs(serr: *const SourceError, buffer
     if serr.errs.is_empty() {
         // Write a single-byte buffer with only the null buffer
         let target: *mut c_char = libc::malloc(1) as *mut c_char;
-        std::slice::from_raw_parts_mut(target, 1)[0] = '\0' as i8;
+        std::slice::from_raw_parts_mut(target, 1)[0] = '\0' as core::ffi::c_char;
         *buffer = target;
 
         // A'ight that's it then
@@ -590,7 +590,7 @@ pub unsafe extern "C" fn serror_serialize_err(serr: *const SourceError, buffer: 
         None => {
             // Write a single-byte buffer with only the null buffer
             let target: *mut c_char = libc::malloc(1) as *mut c_char;
-            std::slice::from_raw_parts_mut(target, 1)[0] = '\0' as i8;
+            std::slice::from_raw_parts_mut(target, 1)[0] = '\0' as core::ffi::c_char;
             *buffer = target;
         },
     }


### PR DESCRIPTION
This does not work on arm because there c_chars are u8's

See: https://github.com/rust-lang/rust/blob/10a76d634781180b4f5402c519f0c237d3be6ee6/library/core/src/ffi/primitives.rs#L37
