### PR TITLE
feat: Add support for alternate download locations

### DIFF
--- a/brane-ctl/src/cli.rs
+++ b/brane-ctl/src/cli.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 use brane_cfg::proxy::ProxyProtocol;
 use brane_ctl::spec::{
-    API_DEFAULT_VERSION, DownloadServicesSubcommand, GenerateBackendSubcommand, GenerateCertsSubcommand, GenerateNodeSubcommand, InclusiveRange,
-    Pair, PolicyInputLanguage, ResolvableNodeKind, StartSubcommand, VersionFix,
+    API_DEFAULT_VERSION, GenerateBackendSubcommand, GenerateCertsSubcommand, GenerateNodeSubcommand, ImageGroup, InclusiveRange, Pair,
+    PolicyInputLanguage, ResolvableNodeKind, StartSubcommand, VersionFix,
 };
 use brane_tsk::docker::ClientVersion;
 use clap::{Parser, Subcommand};
@@ -14,6 +14,8 @@ use specifications::address::{Address, AddressOpt};
 use specifications::arch::Arch;
 use specifications::package::Capability;
 use specifications::version::Version;
+
+const DEFAULT_DOCKER_HOST: &str = "/var/run/docker.sock";
 
 /***** ARGUMENTS *****/
 /// Defines the toplevel arguments for the `branectl` tool.
@@ -190,10 +192,7 @@ pub(crate) enum DownloadSubcommand {
             global = true,
             help = "The processor architecture for which to download the images. Specify '$LOCAL' to use the architecture of the current machine."
         )]
-        arch:    Arch,
-        /// The version of the services to download.
-        #[clap(short, long, default_value=env!("CARGO_PKG_VERSION"), global=true, help="The version of the images to download from GitHub. You can specify 'latest' to download the latest version (but that might be incompatible with this CTL version)")]
-        version: Version,
+        arch:  Arch,
         /// Whether to overwrite existing images or not.
         #[clap(
             short = 'F',
@@ -202,11 +201,19 @@ pub(crate) enum DownloadSubcommand {
             help = "If given, will overwrite services that are already there. Otherwise, these are not overwritten. Note that regardless, a \
                     download will still be performed."
         )]
-        force:   bool,
+        force: bool,
+
+        /// The path of the Docker socket.
+        #[clap(long, default_value = DEFAULT_DOCKER_HOST, env="DOCKER_HOST", help = "The path of the Docker socket to connect to.")]
+        docker_socket: PathBuf,
+        /// The client version to connect with.
+        #[clap(long, default_value=API_DEFAULT_VERSION.as_str(), env="DOCKER_API_VERSION", help="The client version to connect to the Docker instance with.")]
+        docker_client_version: ClientVersion,
 
         /// Whether to download the central or the worker VMs.
-        #[clap(subcommand)]
-        kind: DownloadServicesSubcommand,
+        /// TODO: Enhance docs
+        #[clap(help = "The collection of images")]
+        kind: String,
     },
 }
 

--- a/brane-ctl/src/main.rs
+++ b/brane-ctl/src/main.rs
@@ -57,9 +57,9 @@ async fn main() {
     // Now match on the command
     match args.subcommand {
         CtlSubcommand::Download(subcommand) => match *subcommand {
-            DownloadSubcommand::Services { fix_dirs, path, arch, version, force, kind } => {
+            DownloadSubcommand::Services { fix_dirs, path, arch, force, docker_socket, docker_client_version, kind } => {
                 // Run the subcommand
-                if let Err(err) = download::services(fix_dirs, path, arch, version, force, kind).await {
+                if let Err(err) = download::services(fix_dirs, path, arch, force, docker_socket, docker_client_version, kind).await {
                     error!("{}", err.trace());
                     std::process::exit(1);
                 }

--- a/brane-ctl/src/spec.rs
+++ b/brane-ctl/src/spec.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 
 use brane_cfg::node::NodeKind;
 use brane_tsk::docker::{ClientVersion, ImageSource};
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 use enum_debug::EnumDebug;
 use specifications::address::Address;
 use specifications::version::Version;
@@ -300,30 +300,17 @@ pub struct LogsOpts {
     pub compose_verbose: bool,
 }
 
-
-
-/// A bit awkward here, but defines the subcommand for downloading service images from the repo.
-#[derive(Debug, EnumDebug, Subcommand)]
-pub enum DownloadServicesSubcommand {
+#[derive(Clone, Debug, EnumDebug, ValueEnum)]
+pub enum ImageGroup {
     /// Download the services for a central node.
-    #[clap(name = "central", about = "Downloads the central node services (brane-api, brane-drv, brane-plr, brane-prx)")]
+    #[clap(name = "central")]
     Central,
     /// Download the services for a worker node.
-    #[clap(name = "worker", about = "Downloads the worker node services (brane-reg, brane-job, brane-prx)")]
+    #[clap(name = "worker")]
     Worker,
     /// Download the auxillary services for the central node.
-    #[clap(
-        name = "auxillary",
-        about = "Downloads the auxillary services for the central node. Note that most of these are actually downloaded using Docker."
-    )]
-    Auxillary {
-        /// The path of the Docker socket.
-        #[clap(short, long, default_value = "/var/run/docker.sock", help = "The path of the Docker socket to connect to.")]
-        socket: PathBuf,
-        /// The client version to connect with.
-        #[clap(short, long, default_value=API_DEFAULT_VERSION.as_str(), help="The client version to connect to the Docker instance with.")]
-        client_version: ClientVersion,
-    },
+    #[clap(name = "auxillary")]
+    Auxillary,
 }
 
 /// A bit awkward here, but defines the generate subcommand for the node file. This basically defines the possible kinds of nodes to generate.


### PR DESCRIPTION
This PR introduces new functionality to branectl download services

Where services used to only support GitHub releases (and dockerhub for docker images), the input is now more freeform.

One can now for example input: github:danielvoogsgerd/brane/worker-instance:nightly to download the nightly version from my personal fork.

or in case of the default version on github these will all be synonyms:
- worker-instance
- worker-instance:latest
- brane/worker-instance (or with :latest)
- braneframework/brane/worker-instance (or with :latest)
- github:braneframework/brane/worker-instance (or with :latest)
- gh:braneframework/brane/worker-instance (or with :latest)

It will assume the main repo, the latest version, and github, where a field is omited

For images it also extended the support:

We should now also support GitHub container registry (ghcr.io), so we can start publishing containers there as well.

These can be downloaded using for example: ghcr:brane-api for the brane-api image, note that these images are not yet available as of yet.

There are still some things that need to be sorted out:

- [ ] Testing of various registries and hosts
- [ ] Regexes are incomplete for the allowable charsets
