### PR TITLE
chore(deps): Replace openssl with rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3825,6 +3826,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -5428,6 +5430,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ transform = { git = "https://github.com/Lut99/transform-rs", tag = "v0.2.0" }
 names = { git = "https://github.com/Lut99/names-rs", tag = "v0.1.0", default-features = false, features = [ "rand", "three-lowercase" ]}
 download = { git = "https://github.com/Lut99/download-rs", tag = "v0.1.0", default-features = false, features = ["download"] }
 
+# Note: This does not use any root store by default. This will have to be enabled *explicitly* by the workspace member.
+reqwest = { version = "0.12.0", features = ["rustls-tls-manual-roots"], default-features = false }
+
 [workspace.lints.clippy]
 result_large_err = { level = "allow", priority = 1 }
 suspicious = "deny"

--- a/brane-api/Cargo.toml
+++ b/brane-api/Cargo.toml
@@ -22,7 +22,6 @@ juniper_warp = "0.8.0"
 log = "0.4.22"
 rand = "0.9.0"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
-reqwest = { version = "0.12.0", features = ["rustls-tls-manual-roots"] }
 scylla = "0.12.0"
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
@@ -33,6 +32,9 @@ tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 warp = "0.3.2"
+
+# Workspace dependencies
+reqwest = { workspace = true }
 
 brane-cfg      = { path = "../brane-cfg" }
 brane-prx      = { path = "../brane-prx" }

--- a/brane-cli/Cargo.toml
+++ b/brane-cli/Cargo.toml
@@ -46,7 +46,6 @@ parking_lot = "0.12.1"
 path-clean = "1.0.0"
 prettytable-rs = "0.10.0"
 rand = "0.9.0"
-reqwest = {version = "0.12.0", features = ["rustls-tls-manual-roots","json", "stream", "multipart"] }
 rustls = "0.21.6"
 rustyline = "15.0.0"
 rustyline-derive = "0.11.0"
@@ -62,6 +61,9 @@ tokio-util = { version = "0.7.1", features = ["codec"] }
 tonic = "0.12.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 x509-parser = "0.17.0"
+
+# Workspace dependencies
+reqwest = { workspace = true, features = ["json", "stream", "multipart"] }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-ctl/Cargo.toml
+++ b/brane-ctl/Cargo.toml
@@ -40,7 +40,6 @@ names.workspace = true
 policy = { git = "https://github.com/braneframework/policy-reasoner" }
 srv = { git = "https://github.com/braneframework/policy-reasoner" }
 rand = "0.9.0"
-reqwest = { version = "0.12.0" }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
@@ -48,6 +47,10 @@ shlex = "1.1.0"
 tempfile = "3.10.1"
 thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = [] }
+
+# Workspace dependencies
+# Note that this crate needs a root store because it can download from the internet
+reqwest = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 brane-cfg = { path = "../brane-cfg" }
 brane-shr = { path = "../brane-shr" }

--- a/brane-drv/Cargo.toml
+++ b/brane-drv/Cargo.toml
@@ -17,13 +17,15 @@ env_logger = "0.11.0"
 error-trace.workspace = true
 log = "0.4.22"
 # rdkafka = { version = "0.31", features = ["cmake-build"] }
-reqwest = { version = "0.12.0" }
 serde_json = "1.0.120"
 serde_json_any_key = "2.0.0"
 thiserror = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tokio-stream = "0.1.6"
 tonic = "0.12.0"
+
+# Workspace dependencies
+reqwest = { workspace = true }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-job/Cargo.toml
+++ b/brane-job/Cargo.toml
@@ -22,7 +22,6 @@ hyper = "1.3.0"
 # kube = { version = "0.82", default_features = false, features = ["client"] }
 # k8s-openapi = { version = "0.18", default_features = false, features = ["v1_23"] }
 log = "0.4.22"
-reqwest = { version = "0.12.0", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 serde_json_any_key = "2.0.0"
@@ -31,6 +30,9 @@ thiserror = "2.0.0"
 tokio = { version = "1.38.0", default-features = false, features = ["rt", "macros", "signal"] }
 tokio-stream = "0.1.6"
 tonic = "0.12.0"
+
+# Workspace dependencies
+reqwest = { workspace = true, features = ["json","stream","multipart"] }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-plr/Cargo.toml
+++ b/brane-plr/Cargo.toml
@@ -16,11 +16,13 @@ humanlog.workspace = true
 log = "0.4.22"
 parking_lot = "0.12.1"
 rand = "0.9.0"
-reqwest = "0.12.0"
 serde_json = "1.0.120"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt", "signal"] }
 tonic = "0.12.0"
 warp = "0.3.2"
+
+# Workspace dependencies
+reqwest = { workspace = true }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-prx/Cargo.toml
+++ b/brane-prx/Cargo.toml
@@ -15,7 +15,6 @@ env_logger = "0.11.0"
 error-trace.workspace = true
 log = "0.4.22"
 never-say-never = "6.6.666"
-reqwest = { version = "0.12.0", features = ["json"] }
 rustls = "0.21.6"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
@@ -25,6 +24,9 @@ tokio = { version = "1.38.0", default-features = false, features = ["macros", "r
 tokio-rustls = "0.24.0"
 url = "2.5.0"
 warp = "0.3.2"
+
+# Workspace dependencies
+reqwest = { workspace = true, features = ["json"] }
 
 brane-cfg = { path = "../brane-cfg" }
 brane-tsk = { path = "../brane-tsk" }

--- a/brane-reg/Cargo.toml
+++ b/brane-reg/Cargo.toml
@@ -15,7 +15,6 @@ enum-debug.workspace = true
 env_logger = "0.11.0"
 error-trace.workspace = true
 log = "0.4.22"
-reqwest = "0.12.0"
 rustls = "0.21.6"
 serde = { version = "1.0.204", features = ["rc"] }
 serde_json = "1.0.120"
@@ -25,6 +24,9 @@ thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["rt","rt-multi-thread","macros","io-util", "signal"] }
 tokio-rustls = "0.24.0"
 warp = "0.3.2"
+
+# Workspace dependencies
+reqwest = { workspace = true }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/brane-shr/Cargo.toml
+++ b/brane-shr/Cargo.toml
@@ -18,13 +18,15 @@ humanlog.workspace = true
 indicatif = "0.17.0"
 log = "0.4.22"
 regex = "1.5.0"
-reqwest = { version = "0.12.0", features = ["stream"] }
 sha2 = "0.10.6"
 thiserror = "2.0.0"
 tokio = { version = "1.38.0", features = ["rt","macros"] }
 tokio-stream = "0.1.6"
 tokio-tar = "0.3.0"
 url = "2.5.0"
+
+# Workspace dependencies
+reqwest = { workspace = true, features = ["stream"] }
 
 specifications = { path = "../specifications" }
 

--- a/brane-tsk/Cargo.toml
+++ b/brane-tsk/Cargo.toml
@@ -23,7 +23,6 @@ log = "0.4.22"
 num-traits = "0.2.18"
 parking_lot = "0.12.1"
 rand = "0.9.0"
-reqwest = { version = "0.12.0", features = ["rustls-tls-manual-roots","json","stream","multipart"] }
 serde = "1.0.204"
 serde_json = "1.0.120"
 serde_yaml = { version = "0.0.10", package = "serde_yml" }
@@ -34,6 +33,9 @@ tokio-tar = "0.3.0"
 tokio-util = "0.7.1"
 tonic = "0.12.0"
 uuid = { version = "1.7.0", features = ["v4"] }
+
+# Workspace dependencies
+reqwest = { workspace = true, features = ["json","stream","multipart"] }
 
 brane-ast = { path = "../brane-ast" }
 brane-cfg = { path = "../brane-cfg" }

--- a/specifications/Cargo.toml
+++ b/specifications/Cargo.toml
@@ -21,7 +21,6 @@ jsonwebtoken = "9.2.0"
 log = "0.4.22"
 parking_lot = { version = "0.12.1", features = ["serde"] }
 prost = "0.13.2"
-reqwest = { version = "0.12.0", features = ["json", "stream"] }
 semver = "1.0.0"
 serde = { version = "1.0.204", features = ["derive", "rc"] }
 serde_json = "1.0.120"
@@ -33,6 +32,9 @@ strum_macros = "0.27.0"
 thiserror = "2.0.0"
 tonic = "0.12.0"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
+
+# Workspace dependencies
+reqwest = { workspace = true, features = ["json", "stream"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Setting reqwest as workspace dependency.

Also disable a root store by default. Every crate now as to enable it
themselves in order to use it.

This is going to need some back and forth for this to propagate through
our circular dependency.
