### PR TITLE
Adding detailled Docker profile times to `local_run()` in `brane-cli`

### DIFF
--- a/brane-cli/src/repl.rs
+++ b/brane-cli/src/repl.rs
@@ -31,6 +31,7 @@ use rustyline::history::DefaultHistory;
 use rustyline::validate::{self, MatchingBracketValidator, Validator};
 use rustyline::{CompletionType, Config, Context, EditMode, Editor};
 use rustyline_derive::Helper;
+use specifications::profiling::ProfileScopeHandle;
 
 pub use crate::errors::ReplError as Error;
 use crate::instance::InstanceInfo;
@@ -388,10 +389,12 @@ async fn local_repl(
                 let snippet = Snippet { lines: line_count, workflow };
 
                 // Next, we run the VM (one snippet only ayway)
-                let res: FullValue = run_offline_vm(&mut state, snippet).await.map_err(|source| Error::RunError { what: "offline VM", source })?;
+                let res: FullValue = run_offline_vm(&mut state, snippet, ProfileScopeHandle::dummy())
+                    .await
+                    .map_err(|source| Error::RunError { what: "offline VM", source })?;
 
                 // Then, we collect and process the result
-                if let Err(source) = process_offline_result(res) {
+                if let Err(source) = process_offline_result(res, ProfileScopeHandle::dummy()) {
                     error!("{}", Error::ProcessError { what: "offline VM", source });
                     continue;
                 }

--- a/brane-cli/src/test.rs
+++ b/brane-cli/src/test.rs
@@ -23,6 +23,7 @@ use brane_tsk::input::prompt_for_input;
 use console::style;
 use specifications::data::DataIndex;
 use specifications::package::PackageInfo;
+use specifications::profiling::ProfileScopeHandle;
 use specifications::version::Version;
 
 use crate::errors::TestError;
@@ -178,7 +179,8 @@ pub async fn test_generic(
     )
     .map_err(|source| TestError::RunError { source: run::Error::CompileError(source) })?;
 
-    let result: FullValue = run_offline_vm(&mut state, snippet).await.map_err(|source| TestError::RunError { source })?;
+    let result: FullValue =
+        run_offline_vm(&mut state, snippet, ProfileScopeHandle::dummy()).await.map_err(|source| TestError::RunError { source })?;
 
     // Write the intermediate result if told to do so
     if let Some(file) = show_result {

--- a/brane-ctl/src/download.rs
+++ b/brane-ctl/src/download.rs
@@ -25,6 +25,7 @@ use enum_debug::EnumDebug as _;
 use log::{debug, info, warn};
 use specifications::arch::Arch;
 use specifications::container::Image;
+use specifications::profiling::ProfileScopeHandle;
 use specifications::version::Version;
 use tempfile::TempDir;
 
@@ -272,7 +273,7 @@ pub async fn services(
 
                 // Make sure the image is pulled
                 println!("Downloading auxillary image {}...", style(image).bold().green());
-                ensure_image(&docker, Image::new(name, None::<&str>, None::<&str>), ImageSource::Registry(image.into()))
+                ensure_image(&docker, Image::new(name, None::<&str>, None::<&str>), ImageSource::Registry(image.into()), ProfileScopeHandle::dummy())
                     .await
                     .map_err(|source| Error::PullError { name: name.into(), image: image.into(), source })?;
 

--- a/brane-ctl/src/lifetime.rs
+++ b/brane-ctl/src/lifetime.rs
@@ -37,6 +37,7 @@ use rand::Rng;
 use rand::distr::Alphanumeric;
 use serde::{Deserialize, Serialize};
 use specifications::container::Image;
+use specifications::profiling::ProfileScopeHandle;
 use specifications::version::Version;
 
 pub use crate::errors::LifetimeError as Error;
@@ -487,7 +488,7 @@ async fn load_images(docker: &Docker, images: HashMap<impl AsRef<str>, ImageSour
         };
 
         // Simply rely on ensure_image
-        ensure_image(docker, &image, &image_source).await.map_err(|source| Error::ImageLoadError {
+        ensure_image(docker, &image, &image_source, ProfileScopeHandle::dummy()).await.map_err(|source| Error::ImageLoadError {
             image: Box::new(image),
             image_source: Box::new(image_source),
             source,

--- a/brane-drv/src/planner.rs
+++ b/brane-drv/src/planner.rs
@@ -41,7 +41,7 @@ impl InstancePlanner {
     ///
     /// # Returns
     /// The same workflow as given, but now with all tasks and data transfers planned.
-    pub async fn plan(plr: &Address, app_id: AppId, workflow: Workflow, prof: ProfileScopeHandle<'_>) -> Result<Workflow, PlanError> {
+    pub async fn plan(plr: &Address, app_id: AppId, workflow: Workflow, prof: ProfileScopeHandle) -> Result<Workflow, PlanError> {
         // Generate the ID
         let task_id: String = format!("{}", TaskId::generate());
 

--- a/brane-drv/src/vm.rs
+++ b/brane-drv/src/vm.rs
@@ -81,7 +81,7 @@ impl VmPlugin for InstancePlugin {
         loc: Location,
         name: DataName,
         preprocess: PreprocessKind,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<AccessKind, Self::PreprocessError> {
         info!("Preprocessing {} '{}' on '{}' in a distributed environment...", name.variant(), name.name(), loc);
         debug!("Preprocessing to be done: {:?}", preprocess);
@@ -159,7 +159,7 @@ impl VmPlugin for InstancePlugin {
         global: &Arc<RwLock<Self::GlobalState>>,
         _local: &Self::LocalState,
         info: TaskInfo<'_>,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<Option<FullValue>, Self::ExecuteError> {
         info!("Executing task '{}' at '{}' in a distributed environment...", info.name, info.location);
         debug!("Package: '{}' v{}", info.package_name, info.package_version);
@@ -376,7 +376,7 @@ impl VmPlugin for InstancePlugin {
         _local: &Self::LocalState,
         text: &str,
         newline: bool,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<(), Self::StdoutError> {
         info!("Writing '{}' to stdout in a distributed environment...", text);
         debug!("Newline: {}", if newline { "yes" } else { "no" });
@@ -409,7 +409,7 @@ impl VmPlugin for InstancePlugin {
         loc: &Location,
         name: &str,
         path: &Path,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<(), Self::CommitError> {
         info!("Publicizing intermediate result '{}' living at '{}' in a distributed environment...", name, loc);
         debug!("File: '{}'", path.display());
@@ -426,7 +426,7 @@ impl VmPlugin for InstancePlugin {
         name: &str,
         path: &Path,
         data_name: &str,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<(), Self::CommitError> {
         info!("Committing intermediate result '{}' living at '{}' as '{}' in a distributed environment...", name, loc, data_name);
         debug!("File: '{}'", path.display());
@@ -519,7 +519,7 @@ impl InstanceVm {
         tx: Sender<Result<driving_grpc::ExecuteReply, Status>>,
         id: AppId,
         workflow: Workflow,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> (Self, Result<FullValue, Error>) {
         // Step 0: Load files
         let plr_addr: Address = {

--- a/brane-exe/src/dummy.rs
+++ b/brane-exe/src/dummy.rs
@@ -143,7 +143,7 @@ impl VmPlugin for DummyPlugin {
         _loc: Location,
         name: DataName,
         _preprocess: specifications::data::PreprocessKind,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<AccessKind, Self::PreprocessError> {
         info!("Processing dummy `DummyVm::preprocess()` call for intermediate result '{name}' in {pc}");
 
@@ -155,7 +155,7 @@ impl VmPlugin for DummyPlugin {
         global: &Arc<RwLock<Self::GlobalState>>,
         _local: &Self::LocalState,
         info: TaskInfo<'_>,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<Option<FullValue>, Self::ExecuteError> {
         info!(
             "Processing dummy call to '{}'@'{}' with {} in {}[{}]...",
@@ -179,7 +179,7 @@ impl VmPlugin for DummyPlugin {
         _local: &Self::LocalState,
         text: &str,
         newline: bool,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<(), Self::StdoutError> {
         info!("Processing dummy stdout write (newline: {})...", if newline { "yes" } else { "no" },);
 
@@ -198,7 +198,7 @@ impl VmPlugin for DummyPlugin {
         _loc: &Location,
         name: &str,
         path: &Path,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<(), Self::CommitError> {
         info!("Processing dummy publicize for result '{}' @ '{:?}'...", name, path.display(),);
 
@@ -213,7 +213,7 @@ impl VmPlugin for DummyPlugin {
         name: &str,
         path: &Path,
         data_name: &str,
-        _prof: ProfileScopeHandle<'_>,
+        _prof: ProfileScopeHandle,
     ) -> Result<(), Self::CommitError> {
         info!("Processing dummy commit for result '{}' @ '{:?}' to '{}'...", name, path.display(), data_name,);
 

--- a/brane-exe/src/spec.rs
+++ b/brane-exe/src/spec.rs
@@ -99,7 +99,7 @@ pub trait VmPlugin: 'static + Send + Sync {
         loc: Location,
         name: DataName,
         preprocess: PreprocessKind,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<AccessKind, Self::PreprocessError>;
 
 
@@ -124,7 +124,7 @@ pub trait VmPlugin: 'static + Send + Sync {
         global: &Arc<RwLock<Self::GlobalState>>,
         local: &Self::LocalState,
         info: TaskInfo<'_>,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<Option<FullValue>, Self::ExecuteError>;
 
 
@@ -150,7 +150,7 @@ pub trait VmPlugin: 'static + Send + Sync {
         local: &Self::LocalState,
         text: &str,
         newline: bool,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<(), Self::StdoutError>;
 
 
@@ -178,7 +178,7 @@ pub trait VmPlugin: 'static + Send + Sync {
         loc: &Location,
         name: &str,
         path: &Path,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<(), Self::CommitError>;
 
     /// A function that commits the given intermediate result by promoting it a Data.
@@ -206,7 +206,7 @@ pub trait VmPlugin: 'static + Send + Sync {
         name: &str,
         path: &Path,
         data_name: &str,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<(), Self::CommitError>;
 }
 

--- a/brane-exe/src/vm.rs
+++ b/brane-exe/src/vm.rs
@@ -94,7 +94,7 @@ pub trait Vm {
     async fn run<P: VmPlugin<GlobalState = Self::GlobalState, LocalState = Self::LocalState>>(
         this: Arc<RwLock<Self>>,
         snippet: Workflow,
-        prof: ProfileScopeHandle<'_>,
+        prof: ProfileScopeHandle,
     ) -> Result<FullValue, VmError>
     where
         Self: Sync,

--- a/brane-job/src/worker.rs
+++ b/brane-job/src/worker.rs
@@ -347,7 +347,7 @@ async fn preprocess_transfer_tar_local(
     workflow: Workflow,
     location: Location,
     dataname: DataName,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<AccessKind, PreprocessError> {
     debug!("Preprocessing by executing a data transfer");
     debug!("Downloading '{location}' from '{dataname}' to local machine");
@@ -493,7 +493,7 @@ async fn preprocess_transfer_tar_local(
 // ///
 // /// # Errors
 // /// This function can error for literally a million reasons - but they mostly relate to IO (file access, request success etc).
-// async fn preprocess_transfer_tar_k8s(kinfo: K8sOptions, location: Location, address: impl AsRef<str>, prof: ProfileScopeHandle<'_>) -> Result<AccessKind, PreprocessError> {
+// async fn preprocess_transfer_tar_k8s(kinfo: K8sOptions, location: Location, address: impl AsRef<str>, prof: ProfileScopeHandle) -> Result<AccessKind, PreprocessError> {
 //     debug!("Preprocessing by executing a data transfer");
 //     let address: &str  = address.as_ref();
 //     debug!("Downloading from {} ({}) to Kubernetes cluster", location, address);
@@ -532,7 +532,7 @@ pub async fn preprocess_transfer_tar(
     workflow: Workflow,
     location: Location,
     dataname: DataName,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<AccessKind, PreprocessError> {
     debug!("Preprocessing tar...");
 
@@ -892,7 +892,7 @@ async fn get_container(
 async fn get_container_ids(
     worker_cfg: &WorkerConfig,
     image_path: impl AsRef<Path>,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<(String, Option<String>), ExecuteError> {
     let image_path: &Path = image_path.as_ref();
     debug!("Computing ID and hash for '{}'...", image_path.display());
@@ -980,7 +980,7 @@ async fn ensure_container(
     proxy: Arc<ProxyClient>,
     endpoint: impl AsRef<str>,
     image: &Image,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<(PathBuf, String, Option<String>), ExecuteError> {
     // Download the file if we don't have it locally already
     let image_path: PathBuf = match prof.time_func("cache checking", || get_cached_container(worker_cfg, image)) {
@@ -1021,7 +1021,7 @@ async fn execute_task_local(
     container_path: impl AsRef<Path>,
     tinfo: TaskInfo,
     keep_container: bool,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<FullValue, JobStatus> {
     let container_path: &Path = container_path.as_ref();
     let mut tinfo: TaskInfo = tinfo;
@@ -1149,7 +1149,7 @@ async fn execute_task_local(
 // ///
 // /// # Errors
 // /// This function errors if the task fails for whatever reason or we didn't even manage to launch it.
-// async fn execute_task_k8s(worker_cfg: &WorkerConfig, kinfo: K8sOptions, tx: &Sender<Result<ExecuteReply, Status>>, container_path: impl AsRef<Path>, tinfo: TaskInfo, prof: ProfileScopeHandle<'_>) -> Result<FullValue, JobStatus> {
+// async fn execute_task_k8s(worker_cfg: &WorkerConfig, kinfo: K8sOptions, tx: &Sender<Result<ExecuteReply, Status>>, container_path: impl AsRef<Path>, tinfo: TaskInfo, prof: ProfileScopeHandle) -> Result<FullValue, JobStatus> {
 //     let container_path : &Path    = container_path.as_ref();
 //     let mut tinfo      : TaskInfo = tinfo;
 //     let image          : Image    = tinfo.image.clone().unwrap();
@@ -1275,7 +1275,7 @@ async fn execute_task(
     cinfo: CentralNodeInfo,
     tinfo: TaskInfo,
     keep_container: bool,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<(), ExecuteError> {
     let mut tinfo = tinfo;
 
@@ -1465,7 +1465,7 @@ async fn commit_result(
     worker_cfg: &WorkerConfig,
     name: impl AsRef<str>,
     data_name: impl AsRef<str>,
-    prof: ProfileScopeHandle<'_>,
+    prof: ProfileScopeHandle,
 ) -> Result<(), CommitError> {
     let name: &str = name.as_ref();
     let data_name: &str = data_name.as_ref();


### PR DESCRIPTION
A student wants to benchmark the costs of managing container lifetimes (i.e., spawning them, destroying them, etc). As such, improved (and actually implemented) profile times for local container execution in `brane-cli`.

NOTE: Please don't remove the branch after merging, I'll do that myself to ensure the student can rely on accurate work :)